### PR TITLE
Add repo-relative path injection for test scripts

### DIFF
--- a/scripts/test_app.py
+++ b/scripts/test_app.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+# Determine the repository root relative to this script
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Path to the backend application directory
+BACKEND_DIR = REPO_ROOT / "backend"
+
+# Insert backend path into Python path for module resolution
+if BACKEND_DIR.exists():
+    sys.path.insert(0, str(BACKEND_DIR))
+
+if __name__ == "__main__":
+    print(f"Backend path: {BACKEND_DIR}")

--- a/scripts/test_fastapi_direct.py
+++ b/scripts/test_fastapi_direct.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+# Determine the repository root based on this file location
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Backend directory assumed to live at repo_root / "backend"
+BACKEND_DIR = REPO_ROOT / "backend"
+
+# Add the backend directory to sys.path if it exists
+if BACKEND_DIR.exists():
+    sys.path.insert(0, str(BACKEND_DIR))
+
+if __name__ == "__main__":
+    print(f"Backend path: {BACKEND_DIR}")


### PR DESCRIPTION
## Summary
- add new scripts for FastAPI test harness
- ensure Python path insertion uses `Path(__file__).resolve().parents`

## Testing
- `bun test` *(fails: Cannot find package 'hono')*
- `python scripts/test_fastapi_direct.py`
- `python scripts/test_app.py`
