### PR TITLE
Add basic web navigation components

### DIFF
--- a/apps/web/src/components/Navigation.tsx
+++ b/apps/web/src/components/Navigation.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { trpc } from '../utils/trpc';
+
+export interface NavigationProps {
+  section: number;
+  index: number;
+  onNavigate: (section: number, index: number) => void;
+}
+
+const sections = Array.from({ length: 16 }, (_, i) => i + 1);
+
+const Navigation: React.FC<NavigationProps> = ({ section, index, onNavigate }) => {
+  const { data: pages } = trpc.getPagesBySection.useQuery({ section });
+
+  const pageNumbers = pages?.map(p => p.pageNumber) ?? [];
+  const minIndex = Math.min(...pageNumbers, 1);
+  const maxIndex = Math.max(...pageNumbers, 1);
+
+  const prevDisabled = index <= minIndex;
+  const nextDisabled = index >= maxIndex;
+
+  const handlePrev = () => {
+    if (!prevDisabled) onNavigate(section, index - 1);
+  };
+
+  const handleNext = () => {
+    if (!nextDisabled) onNavigate(section, index + 1);
+  };
+
+  return (
+    <div className="bg-black text-green-500 p-4 border border-green-500 flex items-center gap-4">
+      <button
+        onClick={handlePrev}
+        disabled={prevDisabled}
+        className="border border-green-500 px-2 py-1 disabled:opacity-50"
+      >
+        Prev
+      </button>
+      <select
+        value={section}
+        onChange={e => onNavigate(Number(e.target.value), 1)}
+        className="bg-black border border-green-500 text-green-500 px-2 py-1"
+      >
+        {sections.map(sec => (
+          <option key={sec} value={sec}>Section {sec}</option>
+        ))}
+      </select>
+      <button
+        onClick={handleNext}
+        disabled={nextDisabled}
+        className="border border-green-500 px-2 py-1 disabled:opacity-50"
+      >
+        Next
+      </button>
+    </div>
+  );
+};
+
+export default Navigation;

--- a/apps/web/src/components/PageDisplay.tsx
+++ b/apps/web/src/components/PageDisplay.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { trpc } from '../utils/trpc';
+
+export interface PageDisplayProps {
+  section: number;
+  index: number;
+}
+
+const PageDisplay: React.FC<PageDisplayProps> = ({ section, index }) => {
+  const { data, isLoading } = trpc.getPageById.useQuery({ section, index });
+
+  if (isLoading) {
+    return <div className="bg-black text-green-500 p-4">Loading...</div>;
+  }
+
+  if (!data) {
+    return <div className="bg-black text-green-500 p-4">Page not found</div>;
+  }
+
+  const symbolSrc = `/the-corpus/symbols/${data.sectionName.replace(/\s+/g, '_')}.svg`;
+
+  return (
+    <div className="bg-black text-green-500 p-4 border border-green-500">
+      <h2 className="text-xl mb-2">{data.sectionName}</h2>
+      <img src={symbolSrc} alt={data.sectionName} className="w-12 h-12 mb-2" />
+      <pre className="whitespace-pre-wrap font-mono">{data.text}</pre>
+    </div>
+  );
+};
+
+export default PageDisplay;

--- a/apps/web/src/components/SearchJump.tsx
+++ b/apps/web/src/components/SearchJump.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { trpc } from '../utils/trpc';
+
+export interface SearchJumpProps {
+  onSelect: (section: number, index: number) => void;
+}
+
+const SearchJump: React.FC<SearchJumpProps> = ({ onSelect }) => {
+  const [query, setQuery] = useState('');
+  const [jumpSection, setJumpSection] = useState(1);
+  const [jumpPage, setJumpPage] = useState(1);
+
+  const search = trpc.searchPages.useQuery({ query }, { enabled: false });
+
+  const handleSearch = () => {
+    search.refetch();
+  };
+
+  const handleJump = () => {
+    onSelect(jumpSection, jumpPage);
+  };
+
+  return (
+    <div className="bg-black text-green-500 p-4 border border-green-500">
+      <div className="mb-2 flex gap-2">
+        <input
+          type="text"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          className="bg-black border border-green-500 text-green-500 px-2 py-1 flex-grow"
+          placeholder="Search"
+        />
+        <button onClick={handleSearch} className="border border-green-500 px-2 py-1">Search</button>
+      </div>
+      {search.data && (
+        <ul className="mb-2 max-h-40 overflow-y-auto">
+          {search.data.map(page => (
+            <li key={page.id}>
+              <button
+                className="underline"
+                onClick={() => onSelect(page.section, page.pageNumber)}
+              >
+                Section {page.section} - Page {page.pageNumber}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="flex gap-2 items-center">
+        <input
+          type="number"
+          value={jumpSection}
+          onChange={e => setJumpSection(Number(e.target.value))}
+          className="bg-black border border-green-500 text-green-500 px-2 py-1 w-20"
+        />
+        <input
+          type="number"
+          value={jumpPage}
+          onChange={e => setJumpPage(Number(e.target.value))}
+          className="bg-black border border-green-500 text-green-500 px-2 py-1 w-20"
+        />
+        <button onClick={handleJump} className="border border-green-500 px-2 py-1">Go</button>
+      </div>
+    </div>
+  );
+};
+
+export default SearchJump;

--- a/apps/web/src/utils/trpc.ts
+++ b/apps/web/src/utils/trpc.ts
@@ -1,0 +1,10 @@
+import { createTRPCReact, httpBatchLink } from '@trpc/react-query';
+import type { AppRouter } from '../../../api/src/router';
+
+export const trpc = createTRPCReact<AppRouter>();
+
+export const trpcClient = trpc.createClient({
+  links: [
+    httpBatchLink({ url: '/trpc' }),
+  ],
+});


### PR DESCRIPTION
## Summary
- set up `trpc` client utilities
- add `PageDisplay` component to show page contents and section symbol
- add `Navigation` component for prev/next controls and section select
- add `SearchJump` component with search and jump-to-page inputs

## Testing
- `bun test` *(fails: Cannot find package 'hono')*