### PR TITLE
Add CLI options for chunk script

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,11 @@ newer), and **Python 3** installed.
 
 ## Development Assets
 
-- **Entrance Way Source Text:**  
-  The full, canonical text for The Entrance Way is located at:  
+- **Entrance Way Source Text:**
+  The full, canonical text for The Entrance Way is located at:
   `/packages/db/seed/the-entrance-way.txt`
+  To regenerate the chunked pages file run:
+  `python packages/db/seed/chunk_entrance_way.py --output the-entrance-way-pages.json`
 
 - **Corpus Symbols:**  
   The 16 baseline Corpus symbol SVG files are located at:  

--- a/docs/scratchpad.md
+++ b/docs/scratchpad.md
@@ -18,7 +18,7 @@ All reviewed pages accurately reflect the text in `the-entrance-way.txt` and pag
 
 ## 2025-05-19: Page data enrichment
 
-Regenerated `the-entrance-way-pages.json` using `chunk_entrance_way.py`. The script detected 710 pages and wrote them back to disk. Section headings are pulled from any first bolded line (`**like this**`) on a page. The `entrance-way-section-map.json` file provides the official section and chapter ranges.
+Regenerated `the-entrance-way-pages.json` using `chunk_entrance_way.py` (`python chunk_entrance_way.py --output the-entrance-way-pages.json`). The script detected 710 pages and wrote them back to disk. Section headings are pulled from any first bolded line (`**like this**`) on a page. The `entrance-way-section-map.json` file provides the official section and chapter ranges.
 
 Sample assignments:
 - **Page 1** – Section 1 "an author’s preface" (no chapter)

--- a/packages/db/seed/chunk_entrance_way.py
+++ b/packages/db/seed/chunk_entrance_way.py
@@ -1,14 +1,33 @@
+import argparse
 import json
 import re
 from pathlib import Path
 
 BASE_DIR = Path(__file__).parent
-source_file = BASE_DIR / 'the-entrance-way.txt'
-output_file = BASE_DIR / 'the-entrance-way-pages.json'
 section_map_file = BASE_DIR / 'entrance-way-section-map.json'
 
-text = source_file.read_text(encoding='utf-8')
-section_map = json.loads(section_map_file.read_text(encoding='utf-8'))
+parser = argparse.ArgumentParser(
+    description="Chunk The Entrance Way text into JSON page objects."
+)
+parser.add_argument(
+    "--input",
+    type=Path,
+    default=BASE_DIR / "the-entrance-way.txt",
+    help="Path to the source text file",
+)
+parser.add_argument(
+    "--output",
+    type=Path,
+    default=BASE_DIR / "the-entrance-way-pages.json",
+    help="Path where the pages JSON should be written",
+)
+args = parser.parse_args()
+
+source_file: Path = args.input
+output_file: Path = args.output
+
+text = source_file.read_text(encoding="utf-8")
+section_map = json.loads(section_map_file.read_text(encoding="utf-8"))
 
 pattern = re.compile(r'###Page (\d+)###')
 


### PR DESCRIPTION
## Summary
- allow chunk_entrance_way.py to accept `--input` and `--output`
- document example invocation in README and scratchpad

## Testing
- `bun test` *(fails: Cannot find package 'hono')*