### PR TITLE
Add corpus symbol reference table

### DIFF
--- a/the-corpus/README.md
+++ b/the-corpus/README.md
@@ -1,0 +1,25 @@
+# The Corpus
+
+This directory stores the baseline symbols used throughout Gibsey. Each SVG corresponds to a character or archetype found in **The Entrance Way**. The canonical mapping between sections, pages, and characters can be found in `packages/db/seed/entrance-way-section-map.json`.
+
+## Symbol Map
+
+| Character | SVG filename |
+|-----------|--------------|
+| The Author | The_Author.svg |
+| an author | an_author.svg |
+| Arieol Owlist | arieol_owlist.svg |
+| Cop-E-Right | cop-e-right.svg |
+| Glyph Marrow | glyph_marrow.svg |
+| Jack Parlance | jack_parlance.svg |
+| Jacklyn Variance | jacklyn_variance.svg |
+| London Fox | london_fox.svg |
+| Manny Valentinas | manny_valentinas.svg |
+| New Natalie Weissman | new_natalie_weissman.svg |
+| Old Natalie Weissman | old_natalie_weissman.svg |
+| Oren Progresso | oren_progresso.svg |
+| Phillip Bafflemint | phillip_bafflemint.svg |
+| Princhetta | princhetta.svg |
+| Shamrock Stillman | shamrock_stillman.svg |
+| Todd Fishbone | todd_fishbone.svg |
+


### PR DESCRIPTION
## Summary
- document baseline symbols in `the-corpus/README.md`
- point to `packages/db/seed/entrance-way-section-map.json` for canonical character links

## Testing
- `bun test` *(fails: Cannot find package 'hono')*