### PR TITLE
Add corpusSymbol field

### DIFF
--- a/drizzle/0001_add_corpus_symbol.sql
+++ b/drizzle/0001_add_corpus_symbol.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sections ADD COLUMN corpus_symbol text NOT NULL DEFAULT '';
+ALTER TABLE pages ADD COLUMN corpus_symbol text NOT NULL DEFAULT '';

--- a/packages/db/seed/index.ts
+++ b/packages/db/seed/index.ts
@@ -10,12 +10,26 @@ async function seed() {
   await db.delete(pages);
   await db.delete(sections);
 
-  const sectionMap: Array<{ section: number; section_name: string }> = JSON.parse(
+  const sectionMap: Array<{
+    section: number;
+    section_name: string;
+    connected_character: string;
+  }> = JSON.parse(
     await readFile(new URL('./entrance-way-section-map.json', import.meta.url), 'utf8'),
   );
 
+  const slug = (name: string) =>
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_|_$/g, '');
+
   for (const s of sectionMap) {
-    await db.insert(sections).values({ id: s.section, sectionName: s.section_name });
+    await db.insert(sections).values({
+      id: s.section,
+      sectionName: s.section_name,
+      corpusSymbol: slug(s.connected_character),
+    });
   }
 
   const pagesData: Array<{
@@ -39,6 +53,7 @@ async function seed() {
       id: page.global_index,
       section: sectionRecord.section,
       sectionName: currentSection,
+      corpusSymbol: slug(sectionRecord.connected_character),
       pageNumber: page.page_number,
       globalIndex: page.global_index,
       text: page.text,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -4,12 +4,14 @@ import { relations } from 'drizzle-orm';
 export const sections = sqliteTable('sections', {
   id: integer('id').primaryKey(),
   sectionName: text('section_name').notNull(),
+  corpusSymbol: text('corpus_symbol').notNull(),
 });
 
 export const pages = sqliteTable('pages', {
   id: integer('id').primaryKey(),
   section: integer('section').references(() => sections.id).notNull(),
   sectionName: text('section_name').notNull(),
+  corpusSymbol: text('corpus_symbol').notNull(),
   pageNumber: integer('page_number').notNull(),
   globalIndex: integer('global_index').notNull().unique(),
   text: text('text').notNull(),

--- a/packages/types/entrance-way.ts
+++ b/packages/types/entrance-way.ts
@@ -1,12 +1,14 @@
 export interface Section {
   id: number;
   sectionName: string;
+  corpusSymbol: string;
 }
 
 export interface Page {
   id: number;
   section: number;
   sectionName: string;
+  corpusSymbol: string;
   pageNumber: number;
   globalIndex: number;
   text: string;


### PR DESCRIPTION
## Summary
- expand `sections` and `pages` tables with `corpusSymbol`
- update seed logic to populate corpus symbols
- include `corpusSymbol` in shared types
- provide migration SQL to add the new column

## Testing
- `bun test` *(fails: Cannot find package 'hono')*