### PR TITLE
Add symbol support to page API

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -16,6 +16,16 @@ export const db = drizzle(new Database('db.sqlite'));
 export type AppContext = Context & { user: unknown };
 const t = initTRPC.context<AppContext>().create();
 
+const pageSelect = {
+  id: pages.id,
+  section: pages.section,
+  sectionName: pages.sectionName,
+  symbol: pages.symbol,
+  pageNumber: pages.pageNumber,
+  globalIndex: pages.globalIndex,
+  text: pages.text,
+};
+
 export const appRouter = t.router({
   getPageById: t.procedure
     .input(
@@ -23,7 +33,7 @@ export const appRouter = t.router({
     )
     .query(async ({ input }) => {
       const result = await db
-        .select()
+        .select(pageSelect)
         .from(pages)
         .where(and(eq(pages.section, input.section), eq(pages.pageNumber, input.index)));
       return result[0] ?? null;
@@ -33,7 +43,7 @@ export const appRouter = t.router({
     .input(z.object({ section: z.number() }))
     .query(async ({ input }) => {
       return await db
-        .select()
+        .select(pageSelect)
         .from(pages)
         .where(eq(pages.section, input.section));
     }),
@@ -42,9 +52,18 @@ export const appRouter = t.router({
     .input(z.object({ query: z.string() }))
     .query(async ({ input }) => {
       return await db
-        .select()
+        .select(pageSelect)
         .from(pages)
         .where(like(pages.text, `%${input.query}%`));
+    }),
+
+  getPagesBySymbol: t.procedure
+    .input(z.object({ symbol: z.string() }))
+    .query(async ({ input }) => {
+      return await db
+        .select(pageSelect)
+        .from(pages)
+        .where(eq(pages.symbol, input.symbol));
     }),
 
   getSections: t.procedure.query(async () => {

--- a/packages/db/seed/index.ts
+++ b/packages/db/seed/index.ts
@@ -39,6 +39,7 @@ async function seed() {
       id: page.global_index,
       section: sectionRecord.section,
       sectionName: currentSection,
+      symbol: currentSection.replace(/\s+/g, '_'),
       pageNumber: page.page_number,
       globalIndex: page.global_index,
       text: page.text,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -10,6 +10,7 @@ export const pages = sqliteTable('pages', {
   id: integer('id').primaryKey(),
   section: integer('section').references(() => sections.id).notNull(),
   sectionName: text('section_name').notNull(),
+  symbol: text('symbol').notNull(),
   pageNumber: integer('page_number').notNull(),
   globalIndex: integer('global_index').notNull().unique(),
   text: text('text').notNull(),

--- a/packages/types/entrance-way.ts
+++ b/packages/types/entrance-way.ts
@@ -7,6 +7,7 @@ export interface Page {
   id: number;
   section: number;
   sectionName: string;
+  symbol: string;
   pageNumber: number;
   globalIndex: number;
   text: string;
@@ -24,6 +25,12 @@ export interface GetPagesBySectionParams {
 export interface SearchPagesParams {
   query: string;
 }
+
+export interface GetPagesBySymbolParams {
+  symbol: string;
+}
+
+export type GetPagesBySymbolResult = Page[];
 
 export type GetPageByIdResult = Page | null;
 export type GetPagesBySectionResult = Page[];

--- a/tests/unit/api/entrance-way.test.ts
+++ b/tests/unit/api/entrance-way.test.ts
@@ -62,6 +62,16 @@ describe('searchPages', () => {
   });
 });
 
+describe('getPagesBySymbol', () => {
+  it('returns pages list', async () => {
+    const pages = [{ id: 4 }];
+    mockDb.where.mockResolvedValue(pages);
+    const caller = router.appRouter.createCaller({ user: null } as any);
+    const result = await caller.getPagesBySymbol({ symbol: 'glyph_marrow' });
+    expect(result).toEqual(pages);
+  });
+});
+
 describe('getSections', () => {
   it('returns sections list', async () => {
     const sections = [{ id: 1, sectionName: 'Intro' }];


### PR DESCRIPTION
## Summary
- store symbol in pages schema
- insert symbol when seeding the Entrance Way
- expose new getPagesBySymbol tRPC procedure
- extend shared Page type with symbol
- test the new endpoint

## Testing
- `bun test` *(fails: Cannot find package 'hono' from '/workspace/gibsey/apps/api/src/router.ts')*