### PR TITLE
Add Playwright config and navigation tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "seed": "bun run packages/db/seed/index.ts",
-    "test": "bun test"
+    "test": "bun test",
+    "test:e2e": "bunx playwright test"
   }
 }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  reporter: [['html', { outputFolder: 'playwright-report', open: 'never' }]],
+  outputDir: 'test-results',
+  use: {
+    headless: true,
+    baseURL: 'http://localhost:5173',
+  },
+});

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+
+// Basic navigation through pages using next/prev buttons
+// and switching sections or jumping/searching via UI controls.
+
+test.describe('navigation flow', () => {
+  test('next and previous page navigation', async ({ page }) => {
+    await page.goto('/');
+
+    const pageNumber = page.locator('[data-testid="page-number"]');
+    const initial = await pageNumber.textContent();
+
+    await page.getByRole('button', { name: /next/i }).click();
+    await expect(pageNumber).not.toHaveText(initial ?? '');
+
+    await page.getByRole('button', { name: /prev/i }).click();
+    await expect(pageNumber).toHaveText(initial ?? '');
+  });
+
+  test('section switching and jump/search', async ({ page }) => {
+    await page.goto('/');
+
+    // switch section via select
+    await page.getByRole('combobox').selectOption('2');
+    await expect(page.getByRole('heading', { level: 2 })).toContainText('2');
+
+    // jump directly to a page
+    await page.locator('input[type="number"]').nth(0).fill('1');
+    await page.locator('input[type="number"]').nth(1).fill('3');
+    await page.getByRole('button', { name: /^Go$/ }).click();
+    await expect(page.getByRole('heading', { level: 2 })).toContainText('Section 1');
+
+    // search for a page
+    await page.getByPlaceholder('Search').fill('dawn');
+    await page.getByRole('button', { name: /^Search$/ }).click();
+    await expect(page.getByRole('list')).toBeVisible();
+  });
+});
+
+test.describe('display and theme', () => {
+  test('symbol rendering and retro theme classes', async ({ page }) => {
+    await page.goto('/');
+
+    // symbol is shown for current section
+    const symbol = page.locator('img[src*="/the-corpus/symbols/"]');
+    await expect(symbol).toBeVisible();
+
+    // hauntological theme colors
+    await expect(page.locator('body')).toHaveClass(/bg-black/);
+    await expect(page.locator('body')).toHaveClass(/text-terminal-green/);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Playwright config at the repo root
- create e2e tests for navigation, search and theme
- expose `test:e2e` script using bunx

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test')*
- `bun x playwright test` *(fails: ConnectionRefused downloading package manifest playwright)*