### PR TITLE
Add symbol mapping utility with tests

### DIFF
--- a/packages/db/seed/symbol-map.ts
+++ b/packages/db/seed/symbol-map.ts
@@ -1,0 +1,30 @@
+export const symbolMap: Record<string, string> = {
+  "The Author": "The_Author.svg",
+  "an author": "an_author.svg",
+  "Arieol Owlist": "arieol_owlist.svg",
+  "Cop-E-Right": "cop-e-right.svg",
+  "Glyph Marrow": "glyph_marrow.svg",
+  "Jack Parlance": "jack_parlance.svg",
+  "Jacklyn Variance": "jacklyn_variance.svg",
+  "London Fox": "london_fox.svg",
+  "Manny Valentinas": "manny_valentinas.svg",
+  "New Natalie Weissman": "new_natalie_weissman.svg",
+  "Old Natalie Weissman": "old_natalie_weissman.svg",
+  "Oren Progresso": "oren_progresso.svg",
+  "Phillip Bafflemint": "phillip_bafflemint.svg",
+  "Princhetta": "princhetta.svg",
+  "Shamrock Stillman": "shamrock_stillman.svg",
+  "Todd Fishbone": "todd_fishbone.svg",
+};
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '');
+}
+
+export function characterToSymbol(name: string): string {
+  if (name in symbolMap) return symbolMap[name];
+  return `${slugify(name)}.svg`;
+}

--- a/tests/unit/symbol-map.test.ts
+++ b/tests/unit/symbol-map.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { characterToSymbol } from '../../packages/db/seed/symbol-map';
+
+describe('characterToSymbol', () => {
+  it('returns mapped filename for known character', () => {
+    expect(characterToSymbol('Glyph Marrow')).toBe('glyph_marrow.svg');
+    expect(characterToSymbol('The Author')).toBe('The_Author.svg');
+    expect(characterToSymbol('Cop-E-Right')).toBe('cop-e-right.svg');
+  });
+
+  it('slugifies and appends .svg for unknown names', () => {
+    expect(characterToSymbol('Unknown Character')).toBe('unknown_character.svg');
+    expect(characterToSymbol('A  B  C')).toBe('a_b_c.svg');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `characterToSymbol` with mapping data
- add new unit test verifying mapping and fallback

## Testing
- `bun test tests/unit/symbol-map.test.ts`
- `pytest` *(fails: command not found)*