### PR TITLE
Use helper for corpus symbol slug

### DIFF
--- a/packages/db/seed/symbol-map.ts
+++ b/packages/db/seed/symbol-map.ts
@@ -1,0 +1,28 @@
+export const characterToSymbol = (name: string): string => {
+  const symbolMap: Record<string, string> = {
+    'an author': 'an_author',
+    'London Fox': 'london_fox',
+    'Glyph Marrow': 'glyph_marrow',
+    'Phillip Bafflemint': 'phillip_bafflemint',
+    'Jacklyn Variance': 'jacklyn_variance',
+    'Oren Progresso': 'oren_progresso',
+    'Old Natalie Weissman': 'old_natalie_weissman',
+    'Princhetta': 'princhetta',
+    'Cop-E-Right': 'cop-e-right',
+    'New Natalie Weissman': 'new_natalie_weissman',
+    'Arieol Owlist': 'arieol_owlist',
+    'Jack Parlance': 'jack_parlance',
+    'Manny Valentinas': 'manny_valentinas',
+    'Shamrock Stillman': 'shamrock_stillman',
+    'Todd Fishbone': 'todd_fishbone',
+    'The Author': 'The_Author',
+  };
+
+  if (symbolMap[name]) {
+    return symbolMap[name];
+  }
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '');
+};


### PR DESCRIPTION
## Summary
- add `characterToSymbol` helper for mapping character names to symbol slugs
- use the helper in the DB seed script
- allow optional `corpus_symbol` field in `pagesData` records

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test'; integer primaryKey error)*
- `bun run pytest` *(fails: command not found)*
- `bun run playwright:test` *(fails: ConnectionRefused downloading package manifest)*