### PR TITLE
Add corpus symbol mapping to Python chunker

### DIFF
--- a/packages/db/seed/chunk_entrance_way.py
+++ b/packages/db/seed/chunk_entrance_way.py
@@ -29,6 +29,14 @@ output_file: Path = args.output
 text = source_file.read_text(encoding="utf-8")
 section_map = json.loads(section_map_file.read_text(encoding="utf-8"))
 
+
+# Slug helper replicating the TypeScript seeder logic
+def slug(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+
+# Optional override mapping if certain names need special symbols
+symbol_map: dict[str, str] = {}
+
 pattern = re.compile(r'###Page (\d+)###')
 
 matches = list(pattern.finditer(text))
@@ -36,13 +44,14 @@ matches = list(pattern.finditer(text))
 pages = []
 
 def find_section_data(page_num: int) -> dict:
-    """Return section/chapter info for a given page number."""
+    """Return section/chapter info and corpus symbol for a given page number."""
     for sec in section_map:
         if sec['start_page'] <= page_num <= sec['end_page']:
             data = {
                 'section': sec['section'],
                 'section_name': sec['section_name'],
                 'connected_character': sec['connected_character'],
+                'corpus_symbol': symbol_map.get(sec['connected_character'], slug(sec['connected_character'])),
             }
             for chap in sec.get('chapters', []):
                 if chap['start_page'] <= page_num <= chap['end_page']:
@@ -65,6 +74,7 @@ for i, match in enumerate(matches):
         'section': meta.get('section'),
         'section_name': meta.get('section_name'),
         'connected_character': meta.get('connected_character'),
+        'corpus_symbol': meta.get('corpus_symbol'),
         'text': content,
     }
     if 'chapter' in meta:

--- a/tests/unit/test_chunk_entrance_way.py
+++ b/tests/unit/test_chunk_entrance_way.py
@@ -1,5 +1,10 @@
 import re
 
+def slug(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+
+symbol_map: dict[str, str] = {}
+
 def chunk_text(text, section_map):
     pattern = re.compile(r"###Page (\d+)###")
     matches = list(pattern.finditer(text))
@@ -11,9 +16,14 @@ def chunk_text(text, section_map):
         page_number = int(match.group(1))
         section_name = None
         chapter_name = None
+        connected_character = None
+        corpus_symbol = None
         for sec in section_map:
             if sec["start_page"] <= page_number <= sec["end_page"]:
                 section_name = sec["section_name"]
+                connected_character = sec.get("connected_character")
+                if connected_character:
+                    corpus_symbol = symbol_map.get(connected_character, slug(connected_character))
                 for chap in sec.get("chapters", []):
                     if chap["start_page"] <= page_number <= chap["end_page"]:
                         chapter_name = chap["chapter_name"]
@@ -24,6 +34,8 @@ def chunk_text(text, section_map):
             "page_number": page_number,
             "section": section_name,
             "chapter": chapter_name,
+            "connected_character": connected_character,
+            "corpus_symbol": corpus_symbol,
             "text": content,
         })
     return pages
@@ -45,6 +57,7 @@ def test_chunking_and_metadata():
         {
             "section": 1,
             "section_name": "Section One",
+            "connected_character": "Fox",
             "start_page": 1,
             "end_page": 2,
             "chapters": [
@@ -54,6 +67,7 @@ def test_chunking_and_metadata():
         {
             "section": 2,
             "section_name": "Section Two",
+            "connected_character": "Bear",
             "start_page": 3,
             "end_page": 3,
             "chapters": [],
@@ -67,9 +81,15 @@ def test_chunking_and_metadata():
 
     assert pages[0]["section"] == "Section One"
     assert pages[0]["chapter"] is None
+    assert pages[0]["corpus_symbol"] == "fox"
+    assert pages[0]["connected_character"] == "Fox"
 
     assert pages[1]["section"] == "Section One"
     assert pages[1]["chapter"] == "Chapter One"
+    assert pages[1]["corpus_symbol"] == "fox"
+    assert pages[1]["connected_character"] == "Fox"
 
     assert pages[2]["section"] == "Section Two"
     assert pages[2]["chapter"] is None
+    assert pages[2]["corpus_symbol"] == "bear"
+    assert pages[2]["connected_character"] == "Bear"


### PR DESCRIPTION
## Summary
- extend `chunk_entrance_way.py` to generate `corpus_symbol`
- check `corpus_symbol` in unit tests

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test')*
- `pytest -q tests/unit/test_chunk_entrance_way.py` *(fails: command not found)*