### PR TITLE
Add SymbolFilter e2e test

### DIFF
--- a/tests/e2e/symbol-filter.spec.ts
+++ b/tests/e2e/symbol-filter.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import { execSync } from 'child_process';
+
+// Seed the database once before the suite so symbol data is available
+// for the SymbolFilter component to query.
+test.beforeAll(() => {
+  execSync('bun run packages/db/seed/index.ts', { stdio: 'inherit' });
+});
+
+test.describe('SymbolFilter UI', () => {
+  test('filters pages by selected symbol', async ({ page }) => {
+    await page.goto('/');
+
+    // select a known symbol
+    await page.getByRole('combobox').selectOption('glyph_marrow');
+
+    // expect resulting list to show pages from that symbol's section
+    const listItems = page.locator('ul > li');
+    await expect(listItems.first()).toContainText('Section 3');
+  });
+});


### PR DESCRIPTION
## Summary
- add SymbolFilter Playwright spec
- seed DB before running test

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' and TypeError in schema)*
- `pytest` *(fails: command not found)*
- `bun x playwright test` *(fails: ConnectionRefused downloading package manifest playwright)*