### PR TITLE
Fix router symbols path

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -71,7 +71,7 @@ export const appRouter = t.router({
   }),
 
   getSymbols: t.procedure.query(async () => {
-    const dir = join(__dirname, '../../the-corpus/symbols');
+    const dir = join(__dirname, '../../../the-corpus/symbols');
     const files = readdirSync(dir);
     return files.filter((f) => f.endsWith('.svg'));
   }),


### PR DESCRIPTION
## Summary
- correct path to corpus symbols in API router

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test', TypeError integer("id").primaryKey is not a function)*
- `pytest` *(fails: command not found)*
- `bun x playwright test` *(fails: ConnectionRefused downloading package manifest playwright)*