### PR TITLE
Fix symbol naming conventions

### DIFF
--- a/apps/web/src/components/PageDisplay.tsx
+++ b/apps/web/src/components/PageDisplay.tsx
@@ -21,6 +21,7 @@ const PageDisplay: React.FC<PageDisplayProps> = ({ section, index, page }) => {
     return <div className="bg-black text-terminal-green p-4">Page not found</div>;
   }
 
+  // corpusSymbol values do not include the .svg extension
   const symbolSrc = `/the-corpus/symbols/${data.corpusSymbol}.svg`;
 
   return (

--- a/packages/db/seed/symbol-map.ts
+++ b/packages/db/seed/symbol-map.ts
@@ -1,20 +1,20 @@
 export const symbolMap: Record<string, string> = {
-  "The Author": "The_Author.svg",
-  "an author": "an_author.svg",
-  "Arieol Owlist": "arieol_owlist.svg",
-  "Cop-E-Right": "cop-e-right.svg",
-  "Glyph Marrow": "glyph_marrow.svg",
-  "Jack Parlance": "jack_parlance.svg",
-  "Jacklyn Variance": "jacklyn_variance.svg",
-  "London Fox": "london_fox.svg",
-  "Manny Valentinas": "manny_valentinas.svg",
-  "New Natalie Weissman": "new_natalie_weissman.svg",
-  "Old Natalie Weissman": "old_natalie_weissman.svg",
-  "Oren Progresso": "oren_progresso.svg",
-  "Phillip Bafflemint": "phillip_bafflemint.svg",
-  "Princhetta": "princhetta.svg",
-  "Shamrock Stillman": "shamrock_stillman.svg",
-  "Todd Fishbone": "todd_fishbone.svg",
+  "The Author": "The_Author",
+  "an author": "an_author",
+  "Arieol Owlist": "arieol_owlist",
+  "Cop-E-Right": "cop-e-right",
+  "Glyph Marrow": "glyph_marrow",
+  "Jack Parlance": "jack_parlance",
+  "Jacklyn Variance": "jacklyn_variance",
+  "London Fox": "london_fox",
+  "Manny Valentinas": "manny_valentinas",
+  "New Natalie Weissman": "new_natalie_weissman",
+  "Old Natalie Weissman": "old_natalie_weissman",
+  "Oren Progresso": "oren_progresso",
+  "Phillip Bafflemint": "phillip_bafflemint",
+  "Princhetta": "princhetta",
+  "Shamrock Stillman": "shamrock_stillman",
+  "Todd Fishbone": "todd_fishbone",
 };
 
 function slugify(name: string): string {
@@ -26,5 +26,5 @@ function slugify(name: string): string {
 
 export function characterToSymbol(name: string): string {
   if (name in symbolMap) return symbolMap[name];
-  return `${slugify(name)}.svg`;
+  return slugify(name);
 }

--- a/tests/unit/symbol-map.test.ts
+++ b/tests/unit/symbol-map.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { characterToSymbol } from '../../packages/db/seed/symbol-map';
 
 describe('characterToSymbol', () => {
-  it('returns mapped filename for known character', () => {
-    expect(characterToSymbol('Glyph Marrow')).toBe('glyph_marrow.svg');
-    expect(characterToSymbol('The Author')).toBe('The_Author.svg');
-    expect(characterToSymbol('Cop-E-Right')).toBe('cop-e-right.svg');
+  it('returns mapped slug for known character', () => {
+    expect(characterToSymbol('Glyph Marrow')).toBe('glyph_marrow');
+    expect(characterToSymbol('The Author')).toBe('The_Author');
+    expect(characterToSymbol('Cop-E-Right')).toBe('cop-e-right');
   });
 
-  it('slugifies and appends .svg for unknown names', () => {
-    expect(characterToSymbol('Unknown Character')).toBe('unknown_character.svg');
-    expect(characterToSymbol('A  B  C')).toBe('a_b_c.svg');
+  it('slugifies unknown names', () => {
+    expect(characterToSymbol('Unknown Character')).toBe('unknown_character');
+    expect(characterToSymbol('A  B  C')).toBe('a_b_c');
   });
 });


### PR DESCRIPTION
## Summary
- normalize symbols to store slugs without `.svg`
- update seeding symbol map helper
- adjust unit tests to expect slug values
- document extension rule in `PageDisplay`

## Testing
- `bun test tests/unit` *(fails: integer primaryKey undefined)*
- `pytest` *(fails: command not found)*
- `bun x playwright test` *(fails: ConnectionRefused downloading package manifest playwright)*