### PR TITLE
Add corpus color map and metadata endpoint

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -10,6 +10,7 @@ import { join } from 'path';
 import { eq, and, like } from 'drizzle-orm';
 import { z } from 'zod';
 import { authMiddleware } from '../auth/middleware';
+import colorMap from '../../../the-corpus/colors';
 
 export const db = drizzle(new Database('db.sqlite'));
 
@@ -74,6 +75,10 @@ export const appRouter = t.router({
     const dir = join(__dirname, '../../the-corpus/symbols');
     const files = readdirSync(dir);
     return files.filter((f) => f.endsWith('.svg'));
+  }),
+
+  getCorpusMetadata: t.procedure.query(async () => {
+    return { colors: colorMap };
   }),
 });
 

--- a/docs/scratchpad.md
+++ b/docs/scratchpad.md
@@ -94,6 +94,7 @@ the `connected_character` names from `entrance-way-section-map.json` and maps
 them to the symbol SVGs. An optional `symbolMap` object overrides any slugs that
 do not match a file name exactly. The definitive list of symbols lives in
 [/the-corpus/README.md](../the-corpus/README.md).
+A color mapping for these characters now lives in [../the-corpus/colors.ts](../the-corpus/colors.ts) and is also documented in the corpus README.
 
 ### Regeneration steps
 

--- a/tests/unit/api/entrance-way.test.ts
+++ b/tests/unit/api/entrance-way.test.ts
@@ -15,6 +15,7 @@ vi.mock('bun:sqlite', () => ({ Database: class {} }));
 vi.mock('@trpc/server', () => ({ initTRPC: () => ({ context: () => ({ create: () => ({ router: (obj: any) => obj }) }) }) }));
 vi.mock('drizzle-orm', () => ({ eq: () => ({}), and: () => ({}), like: () => ({}) }));
 vi.mock('../../../apps/api/auth/middleware', () => ({ authMiddleware: () => {} }));
+vi.mock('../../../packages/db/src/schema.ts', () => ({ pages: {}, sections: {} }));
 
 import * as router from '../../../apps/api/src/router';
 
@@ -140,5 +141,14 @@ describe('getSymbols', () => {
     const caller = router.appRouter.createCaller({ user: null } as any);
     const result = await caller.getSymbols();
     expect(result).toEqual(['a.svg']);
+  });
+});
+
+describe('getCorpusMetadata', () => {
+  it('returns color mapping', async () => {
+    const caller = router.appRouter.createCaller({ user: null } as any);
+    const result = await caller.getCorpusMetadata();
+    expect(result).toHaveProperty('colors');
+    expect(result.colors).toBeDefined();
   });
 });

--- a/the-corpus/README.md
+++ b/the-corpus/README.md
@@ -23,3 +23,26 @@ This directory stores the baseline symbols used throughout Gibsey. Each SVG corr
 | Shamrock Stillman | shamrock_stillman.svg |
 | Todd Fishbone | todd_fishbone.svg |
 
+
+## Color Map
+
+The following table defines a hexadecimal color for each character. These values are exported from [`colors.ts`](./colors.ts).
+
+| Character | Hex Color |
+|-----------|-----------|
+| The Author | #ef4444 |
+| an author | #f97316 |
+| Arieol Owlist | #f59e0b |
+| Cop-E-Right | #eab308 |
+| Glyph Marrow | #84cc16 |
+| Jack Parlance | #22c55e |
+| Jacklyn Variance | #10b981 |
+| London Fox | #14b8a6 |
+| Manny Valentinas | #06b6d4 |
+| New Natalie Weissman | #0ea5e9 |
+| Old Natalie Weissman | #3b82f6 |
+| Oren Progresso | #6366f1 |
+| Phillip Bafflemint | #8b5cf6 |
+| Princhetta | #a855f7 |
+| Shamrock Stillman | #d946ef |
+| Todd Fishbone | #ec4899 |

--- a/the-corpus/colors.ts
+++ b/the-corpus/colors.ts
@@ -1,0 +1,20 @@
+export const colorMap: Record<string, string> = {
+  "The Author": "#ef4444",
+  "an author": "#f97316",
+  "Arieol Owlist": "#f59e0b",
+  "Cop-E-Right": "#eab308",
+  "Glyph Marrow": "#84cc16",
+  "Jack Parlance": "#22c55e",
+  "Jacklyn Variance": "#10b981",
+  "London Fox": "#14b8a6",
+  "Manny Valentinas": "#06b6d4",
+  "New Natalie Weissman": "#0ea5e9",
+  "Old Natalie Weissman": "#3b82f6",
+  "Oren Progresso": "#6366f1",
+  "Phillip Bafflemint": "#8b5cf6",
+  "Princhetta": "#a855f7",
+  "Shamrock Stillman": "#d946ef",
+  "Todd Fishbone": "#ec4899",
+};
+
+export default colorMap;


### PR DESCRIPTION
## Summary
- add `/the-corpus/colors.ts` with character color definitions
- document color table in corpus README and mention in docs scratchpad
- expose new `getCorpusMetadata` tRPC endpoint returning color map
- test for new endpoint

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test'; schema init fails)*
- `bun run pytest` *(fails: command not found)*
- `bun run playwright:test` *(fails: ConnectionRefused downloading package manifest playwright)*