### PR TITLE
Add symbol metadata to API

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -5,8 +5,7 @@ import { trpcServer } from '@hono/trpc-server';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
 import { pages, sections } from '../../../packages/db/src/schema';
-import { readdirSync } from 'fs';
-import { join } from 'path';
+import { symbolMetadata } from '../../../the-corpus/symbols/metadata';
 import { eq, and, like } from 'drizzle-orm';
 import { z } from 'zod';
 import { authMiddleware } from '../auth/middleware';
@@ -71,9 +70,7 @@ export const appRouter = t.router({
   }),
 
   getSymbols: t.procedure.query(async () => {
-    const dir = join(__dirname, '../../the-corpus/symbols');
-    const files = readdirSync(dir);
-    return files.filter((f) => f.endsWith('.svg'));
+    return symbolMetadata;
   }),
 });
 

--- a/apps/web/src/components/PageDisplay.tsx
+++ b/apps/web/src/components/PageDisplay.tsx
@@ -13,6 +13,7 @@ const PageDisplay: React.FC<PageDisplayProps> = ({ section, index, page }) => {
   const { data, isLoading } = (!page && section && index)
     ? trpc.getPageById.useQuery({ section, index })
     : { data: page, isLoading: false };
+  const { data: metaList } = trpc.getSymbols.useQuery();
 
   if (isLoading) {
     return <div className="bg-black text-terminal-green p-4">Loading...</div>;
@@ -22,11 +23,20 @@ const PageDisplay: React.FC<PageDisplayProps> = ({ section, index, page }) => {
   }
 
   const symbolSrc = `/the-corpus/symbols/${data.corpusSymbol}.svg`;
+  const meta = metaList?.find(m => m.filename.replace('.svg', '') === data.corpusSymbol);
 
   return (
     <div className="bg-black text-terminal-green p-4 border border-terminal-green">
       <h2 className="text-xl mb-2">{data.sectionName}</h2>
-      <img src={symbolSrc} alt={data.sectionName} className="w-12 h-12 mb-2" />
+      <img
+        src={symbolSrc}
+        alt={data.sectionName}
+        className="w-12 h-12 mb-2 border"
+        style={{ borderColor: meta?.color }}
+      />
+      {meta?.orientation && (
+        <div className="mb-2">Orientation: {meta.orientation}</div>
+      )}
       <pre className="whitespace-pre-wrap font-mono">{data.text}</pre>
     </div>
   );

--- a/apps/web/src/components/SymbolFilter.tsx
+++ b/apps/web/src/components/SymbolFilter.tsx
@@ -18,10 +18,15 @@ const SymbolFilter: React.FC = () => {
       >
         <option value="">Filter by symbol</option>
         {symbols?.map(s => {
-          const value = s.replace('.svg', '');
+          const value = s.filename.replace('.svg', '');
           return (
-            <option key={value} value={value}>
+            <option
+              key={value}
+              value={value}
+              style={{ color: s.color }}
+            >
               {value}
+              {s.orientation ? ` (${s.orientation})` : ''}
             </option>
           );
         })}

--- a/packages/types/entrance-way.ts
+++ b/packages/types/entrance-way.ts
@@ -36,3 +36,5 @@ export type GetPagesBySymbolResult = Page[];
 export type GetPageByIdResult = Page | null;
 export type GetPagesBySectionResult = Page[];
 export type SearchPagesResult = Page[];
+
+export * from './symbols';

--- a/packages/types/symbols.ts
+++ b/packages/types/symbols.ts
@@ -1,0 +1,9 @@
+export interface SymbolMetadata {
+  character: string;
+  filename: string;
+  color: string;
+  orientation?: string;
+  motif?: string;
+}
+
+export type GetSymbolsResult = SymbolMetadata[];

--- a/tests/unit/api/entrance-way.test.ts
+++ b/tests/unit/api/entrance-way.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as bunTest from 'bun:test';
-import * as fs from 'fs';
 
 // Bun's vi helper lacks `mock`, so map it when missing
 if (!('mock' in vi)) {
@@ -15,6 +14,9 @@ vi.mock('bun:sqlite', () => ({ Database: class {} }));
 vi.mock('@trpc/server', () => ({ initTRPC: () => ({ context: () => ({ create: () => ({ router: (obj: any) => obj }) }) }) }));
 vi.mock('drizzle-orm', () => ({ eq: () => ({}), and: () => ({}), like: () => ({}) }));
 vi.mock('../../../apps/api/auth/middleware', () => ({ authMiddleware: () => {} }));
+vi.mock('../../../the-corpus/symbols/metadata', () => ({
+  symbolMetadata: [{ character: 'Test', filename: 'a.svg', color: '#fff', orientation: 'upright' }],
+}));
 
 import * as router from '../../../apps/api/src/router';
 
@@ -135,10 +137,11 @@ describe('getSections', () => {
 });
 
 describe('getSymbols', () => {
-  it('returns svg file names', async () => {
-    vi.spyOn(fs, 'readdirSync').mockReturnValue(['a.svg', 'b.png'] as any);
+  it('returns metadata list', async () => {
     const caller = router.appRouter.createCaller({ user: null } as any);
     const result = await caller.getSymbols();
-    expect(result).toEqual(['a.svg']);
+    expect(result).toEqual([
+      { character: 'Test', filename: 'a.svg', color: '#fff', orientation: 'upright' },
+    ]);
   });
 });

--- a/the-corpus/symbols/metadata.ts
+++ b/the-corpus/symbols/metadata.ts
@@ -1,0 +1,26 @@
+export interface SymbolMetadata {
+  character: string;
+  filename: string;
+  color: string;
+  orientation?: string;
+  motif?: string;
+}
+
+export const symbolMetadata: SymbolMetadata[] = [
+  { character: "The Author", filename: "The_Author.svg", color: "#e5b3d1", orientation: "inverted" },
+  { character: "an author", filename: "an_author.svg", color: "#f3d9b1", orientation: "upright" },
+  { character: "Arieol Owlist", filename: "arieol_owlist.svg", color: "#d1e5b3", orientation: "upright" },
+  { character: "Cop-E-Right", filename: "cop-e-right.svg", color: "#b3d1e5", orientation: "right-facing" },
+  { character: "Glyph Marrow", filename: "glyph_marrow.svg", color: "#cdb3e5", orientation: "upright" },
+  { character: "Jack Parlance", filename: "jack_parlance.svg", color: "#e5c0b3", orientation: "left-facing" },
+  { character: "Jacklyn Variance", filename: "jacklyn_variance.svg", color: "#b3e5d6", orientation: "upright" },
+  { character: "London Fox", filename: "london_fox.svg", color: "#e5b3b3", orientation: "upright" },
+  { character: "Manny Valentinas", filename: "manny_valentinas.svg", color: "#b3e5d1", orientation: "upright" },
+  { character: "New Natalie Weissman", filename: "new_natalie_weissman.svg", color: "#e5d1b3", orientation: "upright" },
+  { character: "Old Natalie Weissman", filename: "old_natalie_weissman.svg", color: "#d1b3e5", orientation: "upright" },
+  { character: "Oren Progresso", filename: "oren_progresso.svg", color: "#b3e5c4", orientation: "upright" },
+  { character: "Phillip Bafflemint", filename: "phillip_bafflemint.svg", color: "#b3c4e5", orientation: "upright" },
+  { character: "Princhetta", filename: "princhetta.svg", color: "#e5b3c4", orientation: "upright" },
+  { character: "Shamrock Stillman", filename: "shamrock_stillman.svg", color: "#c4e5b3", orientation: "upright" },
+  { character: "Todd Fishbone", filename: "todd_fishbone.svg", color: "#b3e5b3", orientation: "upright" },
+];


### PR DESCRIPTION
## Summary
- add corpus symbol metadata describing filename, color and orientation
- expose metadata via tRPC API
- show color/orientation in SymbolFilter and PageDisplay
- update shared types and tests

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test', TypeError from drizzle ORM)*