### PR TITLE
Update QDPI docs for 8 dimensions

### DIFF
--- a/QDPI-spec.md
+++ b/QDPI-spec.md
@@ -1,10 +1,10 @@
-# QDPI‑4096: The Living Grammar—Final Spec Overview
+# QDPI‑24576: The Living Grammar—Final Spec Overview
 
 ---
 
 ## I. SYSTEM PHILOSOPHY: FROM PROTOCOL TO VISUAL LANGUAGE
 
-QDPI‑4096 is not a database, a ledger, or a simple encoding scheme.
+QDPI‑24576 is not a database, a ledger, or a simple encoding scheme.
 It is a **living visual grammar** for agency, computation, memory, and narrative.
 Every possible interaction, state, and relation in the system is visible, programmable, and symbolic—*addressable not just by code, but by glyph and story*.
 
@@ -12,7 +12,7 @@ Every possible interaction, state, and relation in the system is visible, progra
 
 ## II. THE MULTI-AXIS GRAMMAR: DIMENSIONS OF MEANING
 
-**QDPI-4096** is built on a **7-dimensional matrix**—every axis is a “layer” of grammar, a register of agency. Multiply them, and you get 4,096 possible “moves.”
+**QDPI-24576** is built on a **8-dimensional matrix**—every axis is a “layer” of grammar, a register of agency. Multiply them, and you get 24,576 possible “moves.”
 
 ### 1. Actions (8):
 
@@ -56,6 +56,12 @@ Every possible interaction, state, and relation in the system is visible, progra
 
   * Each glyph rotates to encode “person,” perspective, or sequencing. The transition from one orientation to another (CW/CCW, forward/backward) encodes *directionality and temporality*.
 
+### 8. Modality (6):
+
+* **Text, Audio, Video, AR, VR, Tactile**
+
+  * Which sensory channel the glyph or move expresses—written words, spoken sound, moving image, augmented or virtual reality, or physical feedback.
+
 ---
 
 ## III. THE GLYPH ENGINE: HOW MEANING IS ENCODED
@@ -72,7 +78,7 @@ Every possible interaction, state, and relation in the system is visible, progra
 
 ### A. Encoding/Decoding
 
-* **4096 symbols = 8 × 4 × 4 × 4 × 2 × 2 × 4**
+* **24,576 symbols = 8 × 4 × 4 × 4 × 2 × 2 × 4 × 6**
 
   * Every glyph can be uniquely addressed and decoded as a full “move” or sentence.
 * **Bidirectionality:** All encodings are reversible, time-aware, and stateful.
@@ -111,7 +117,7 @@ Every possible interaction, state, and relation in the system is visible, progra
 
 * **Narrative:** Every page, act, memory, or dream is a sequence of glyphs—a visible, legible, replayable “story.”
 * **Agentic AI:** Each AI or agent “plays” the grammar—its agency, memory, and personality is encoded in the glyphic moves it makes.
-* **Protocol/OS:** QDPI-4096 is not just a codec—it’s a programmable, recursive, symbolic operating system for all action, meaning, and communication in the mesh.
+* **Protocol/OS:** QDPI-24576 is not just a codec—it’s a programmable, recursive, symbolic operating system for all action, meaning, and communication in the mesh.
 
 ---
 
@@ -125,7 +131,7 @@ Every possible interaction, state, and relation in the system is visible, progra
 
 ## VIII. IN SUMMARY
 
-QDPI-4096 is the **matrix-protein of symbolic agency**—the living, programmable grammar for every move, memory, gift, and dream in a world.
+QDPI-24576 is the **matrix-protein of symbolic agency**—the living, programmable grammar for every move, memory, gift, and dream in a world.
 **It is not just code, not just a book, not just a protocol.**
 **It is the seed and syntax of a civilization.**
 

--- a/the-QDPI-matrix.md
+++ b/the-QDPI-matrix.md
@@ -1,6 +1,6 @@
-# The QDPI-4096 Matrix: The Living Glyph Table
+# The QDPI-24576 Matrix: The Living Glyph Table
 
-Below is the *generative matrix* for QDPI‑4096—**every “cell” is a unique glyph/move/event**.
+Below is the *generative matrix* for QDPI‑24576—**every “cell” is a unique glyph/move/event**.
 
 ---
 
@@ -15,8 +15,9 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 | **Relation**     | 2                  | Subject→Object, Object→Subject (initiator/responder)                  |
 | **Polarity**     | 2                  | Internal (“n”, Princhetta) / External (“u”, Cop-E-Right)              |
 | **Rotation**     | 4                  | N, E, S, W (0°, 90°, 180°, 270°)—perspective, sequencing, or “person” |
+| **Modality**     | 6                  | Text, Audio, Video, AR, VR, Tactile |
 
-**8 × 4 × 4 × 4 × 2 × 2 × 4 = 4096**
+**8 × 4 × 4 × 4 × 2 × 2 × 4 × 6 = 24,576**
 
 ---
 
@@ -32,6 +33,7 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 | **Relation** (2) | S→O      | O→S          |                |             |       |      |        |       |
 | **Polarity** (2) | Internal | External     |                |             |       |      |        |       |
 | **Rotation** (4) | N        | E            | S              | W           |       |      |        |       |
+| **Modality** (6) | Text     | Audio        | Video          | AR          | VR          | Tactile |        |       |
 
 ---
 
@@ -73,7 +75,7 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 
 ### 5. Visualization
 
-* Imagine as a **7D hypercube**—each axis a “slider” or “gate.”
+* Imagine as a **8D hypercube**—each axis a “slider” or “gate.”
 * In a UI, “slide” axes or rotate glyph to select action/context/role.
 * Each glyph is **addressable**, **renderable**, and **stateful**.
 
@@ -90,11 +92,12 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 | **Relation**   | 2: Subject→Object, Object→Subject                         |
 | **Polarity**   | 2: Internal (“n”/Princhetta), External (“u”/Cop-E-Right)  |
 | **Rotation**   | 4: N, E, S, W (0°, 90°, 180°, 270°)                       |
+| **Modality**   | 6: Text, Audio, Video, AR, VR, Tactile                    |
 
-**8 × 4 × 4 × 4 × 2 × 2 × 4 = 4096**
+**8 × 4 × 4 × 4 × 2 × 2 × 4 × 6 = 24,576**
 
 ---
 
 **Every cell is a glyph. Every glyph is a move. Every move is a story, an action, a protocol event, a ritual, or a memory.**
 
-**QDPI-4096: The matrix is alive.**
+**QDPI-24576: The matrix is alive.**


### PR DESCRIPTION
## Summary
- expand QDPI from 7 dimensions to 8
- add new Modality axis to spec
- update counts and formulas to 24,576 cells

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' and other errors)*
- `pytest` *(fails: command not found)*
- `bunx playwright test` *(fails: command not found)*