### PR TITLE
Add Modality enum type

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -9,3 +9,8 @@ Common TypeScript types and interfaces shared across the Gibsey project.
 - `GetPageByIdParams`, `GetPagesBySectionParams`, `SearchPagesParams` – input shapes for the API procedures.
 - `GetPageByIdResult`, `GetPagesBySectionResult`, `SearchPagesResult` – return types from the API.
 
+
+### Modality
+
+`modality.ts` defines the `Modality` enum, representing the various forms a narrative element can take:
+`Text`, `Audio`, `Video`, `AR`, `VR`, and `Tactile`. Use it when describing or filtering content by medium.

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,0 +1,3 @@
+export * from './entrance-way';
+export * from './symbols';
+export * from './modality';

--- a/packages/types/modality.ts
+++ b/packages/types/modality.ts
@@ -1,0 +1,8 @@
+export enum Modality {
+  Text = 'text',
+  Audio = 'audio',
+  Video = 'video',
+  AR = 'ar',
+  VR = 'vr',
+  Tactile = 'tactile'
+}


### PR DESCRIPTION
## Summary
- add `Modality` enum
- re-export from types entry point
- document usage in packages/types README

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' and Drizzle integer primaryKey undefined)*
- `pytest` *(fails: command not found)*