### PR TITLE
Add glyph codec with modality

### DIFF
--- a/packages/utils/glyphCodec.ts
+++ b/packages/utils/glyphCodec.ts
@@ -1,0 +1,108 @@
+export enum Action {
+  Read = 0,
+  Index,
+  Prompt,
+  React,
+  Write,
+  Save,
+  Forget,
+  Dream,
+}
+
+export enum Context {
+  Page = 0,
+  Prompt,
+  Reaction,
+  Generation,
+}
+
+export enum State {
+  Public = 0,
+  Private,
+  Sacrifice,
+  Gift,
+}
+
+export enum Role {
+  Human = 0,
+  AI,
+  WholeSystem,
+  PartSystem,
+}
+
+export enum Relation {
+  S2O = 0,
+  O2S,
+}
+
+export enum Polarity {
+  Internal = 0,
+  External,
+}
+
+export enum Rotation {
+  N = 0,
+  E,
+  S,
+  W,
+}
+
+export enum Modality {
+  Text = 0,
+  Image,
+  Audio,
+  Video,
+}
+
+export interface Glyph {
+  action: Action;
+  context: Context;
+  state: State;
+  role: Role;
+  relation: Relation;
+  polarity: Polarity;
+  rotation: Rotation;
+  modality?: Modality;
+}
+
+export function encodeGlyph(g: Glyph): number {
+  const modality = g.modality ?? Modality.Text;
+  return (
+    (modality << 13) |
+    (g.action << 10) |
+    (g.context << 8) |
+    (g.state << 6) |
+    (g.role << 4) |
+    (g.relation << 3) |
+    (g.polarity << 2) |
+    g.rotation
+  );
+}
+
+export function decodeGlyph(code: number): Glyph {
+  const rotation = code & 0b11;
+  code >>= 2;
+  const polarity = code & 0b1;
+  code >>= 1;
+  const relation = code & 0b1;
+  code >>= 1;
+  const role = code & 0b11;
+  code >>= 2;
+  const state = code & 0b11;
+  code >>= 2;
+  const context = code & 0b11;
+  code >>= 2;
+  const action = code & 0b111;
+  code >>= 3;
+  const modality = code & 0b11;
+  return {
+    action: action as Action,
+    context: context as Context,
+    state: state as State,
+    role: role as Role,
+    relation: relation as Relation,
+    polarity: polarity as Polarity,
+    rotation: rotation as Rotation,
+    modality: (modality as Modality) ?? Modality.Text,
+  };
+}

--- a/tests/unit/glyphCodec.test.ts
+++ b/tests/unit/glyphCodec.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  encodeGlyph,
+  decodeGlyph,
+  Action,
+  Context,
+  State,
+  Role,
+  Relation,
+  Polarity,
+  Rotation,
+  Modality,
+  Glyph,
+} from '../../packages/utils/glyphCodec';
+
+describe('glyphCodec', () => {
+  it('round trips with explicit modality', () => {
+    const glyph: Glyph = {
+      action: Action.Write,
+      context: Context.Generation,
+      state: State.Public,
+      role: Role.AI,
+      relation: Relation.S2O,
+      polarity: Polarity.Internal,
+      rotation: Rotation.N,
+      modality: Modality.Image,
+    };
+    const code = encodeGlyph(glyph);
+    const decoded = decodeGlyph(code);
+    expect(decoded).toEqual(glyph);
+  });
+
+  it('defaults modality to Text when missing', () => {
+    const glyph: Glyph = {
+      action: Action.Read,
+      context: Context.Page,
+      state: State.Private,
+      role: Role.Human,
+      relation: Relation.O2S,
+      polarity: Polarity.External,
+      rotation: Rotation.E,
+    };
+    const code = encodeGlyph(glyph);
+    const decoded = decodeGlyph(code);
+    expect(decoded).toEqual({ ...glyph, modality: Modality.Text });
+  });
+});


### PR DESCRIPTION
## Summary
- add `glyphCodec` utility for encoding/decoding glyphs with a new `modality` axis
- include unit tests showing round‑trip behaviour and defaulting to text modality

## Testing
- `bun test`
- `pytest` *(fails: command not found)*
- `bun x playwright test` *(fails: network access required)*