### PR TITLE
Add QDPI modality examples and vault sample

### DIFF
--- a/docs/vault-example.md
+++ b/docs/vault-example.md
@@ -1,0 +1,27 @@
+# Vault Example: Dream Move in Video Modality
+
+This example shows how a single move might be recorded in the Gibsey Vault.
+It uses the full QDPI axes including **Modality**.
+
+```yaml
+id: 42
+timestamp: "2025-05-21T12:00:00Z"
+action: Dream
+context: Prompt
+state: Gift
+role: Whole System
+relation: Object→Subject
+polarity: External
+rotation: S
+modality: Video
+content: |
+  A shimmering montage appears, narrated by the system.
+  Colors flicker across the screen as the dream answers the prompt.
+```
+
+### First AR Move (Narrative Log)
+
+The first time an AR glyph fired, the user held their phone over the
+page. Symbols rotated eastward, the room glowed, and the system
+whispered a welcome. That moment was logged as the inaugural **AR move**
+and marked a new chapter in the Vault.

--- a/the-QDPI-matrix.md
+++ b/the-QDPI-matrix.md
@@ -15,8 +15,25 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 | **Relation**     | 2                  | Subject→Object, Object→Subject (initiator/responder)                  |
 | **Polarity**     | 2                  | Internal (“n”, Princhetta) / External (“u”, Cop-E-Right)              |
 | **Rotation**     | 4                  | N, E, S, W (0°, 90°, 180°, 270°)—perspective, sequencing, or “person” |
+| **Modality**     | 4                  | Text, Audio, Video, AR |
 
-**8 × 4 × 4 × 4 × 2 × 2 × 4 = 4096**
+**8 × 4 × 4 × 4 × 2 × 2 × 4 × 4 = 16,384 (with Modality)**
+
+---
+
+## Example Glyph Tables with Modality
+
+### Table 1: Dream in Video
+
+| Action | Context | State | Role | Relation | Polarity | Rotation | Modality | Glyph Meaning |
+| ------ | ------- | ----- | ---- | -------- | -------- | -------- | -------- | ------------- |
+| Dream  | Prompt  | Gift  | Whole Sys | O→S | External | S | Video | "The system dreams in response to a prompt, gifting a video to the user." |
+
+### Table 2: First AR Move
+
+| Action | Context | State  | Role  | Relation | Polarity | Rotation | Modality | Glyph Meaning |
+| ------ | ------- | ------ | ----- | -------- | -------- | -------- | -------- | ------------- |
+| Read   | Page    | Public | Human | S→O      | External | E        | AR       | "A user reads an augmented page, the first AR move recorded." |
 
 ---
 
@@ -90,8 +107,9 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 | **Relation**   | 2: Subject→Object, Object→Subject                         |
 | **Polarity**   | 2: Internal (“n”/Princhetta), External (“u”/Cop-E-Right)  |
 | **Rotation**   | 4: N, E, S, W (0°, 90°, 180°, 270°)                       |
+| **Modality**   | 4: Text, Audio, Video, AR                                 |
 
-**8 × 4 × 4 × 4 × 2 × 2 × 4 = 4096**
+**8 × 4 × 4 × 4 × 2 × 2 × 4 × 4 = 16,384 (with Modality)**
 
 ---
 


### PR DESCRIPTION
## Summary
- expand the QDPI table with a Modality axis
- include example glyph tables for Video and AR moves
- document a sample Vault entry for a Dream move in Video modality

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' and drizzle schema error)*
- `pytest` *(fails: command not found)*
- `bunx playwright test` *(fails: command not found)*