### PR TITLE
Add modality selector UI

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,1 +1,9 @@
 Frontend web application for Gibsey, providing the main user interface.
+
+### Output Modality
+
+Pages can now be requested in different modalities (text, audio, or visual).
+The `PageDisplay` component includes a new `ModalitySelector` dropdown that
+allows choosing the desired output format. The selected modality is sent as an
+`x-modality` header with each tRPC request (placeholder until backend support is
+implemented).

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,19 +1,32 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { trpc } from './trpc';
 import Navigation from './components/Navigation';
 import PageDisplay from './components/PageDisplay';
 import SearchJump from './components/SearchJump';
 import SymbolFilter from './components/SymbolFilter';
 import ColorFilter from './components/ColorFilter';
+import { setModality } from './utils/modalityStore';
 
 const App: React.FC = () => {
   const [section, setSection] = useState(1);
   const [index, setIndex] = useState(1);
+  const [modality, setModalityState] = useState('text');
+
+  useEffect(() => {
+    setModality(modality);
+  }, [modality]);
   const { data: sections } = trpc.getSections.useQuery();
-  const page = trpc.getPageById.useQuery({ section, index });
+  const page = trpc.getPageById.useQuery(
+    { section, index },
+    { context: { modality } },
+  );
 
   const currentColor =
     sections?.find((s) => s.id === section)?.color ?? '#00FF00';
+
+  const handleModalityChange = (m: string) => {
+    setModalityState(m);
+  };
 
   const handleNavigate = (sec: number, idx: number) => {
     setSection(sec);
@@ -29,7 +42,13 @@ const App: React.FC = () => {
         sections={sections}
         color={currentColor}
       />
-      <PageDisplay section={section} index={index} color={currentColor} />
+      <PageDisplay
+        section={section}
+        index={index}
+        modality={modality}
+        onModalityChange={handleModalityChange}
+        color={currentColor}
+      />
       <SearchJump onSelect={handleNavigate} color={currentColor} />
       <div className="flex gap-4">
         <SymbolFilter color={currentColor} />

--- a/apps/web/src/components/ModalitySelector.tsx
+++ b/apps/web/src/components/ModalitySelector.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export interface ModalitySelectorProps {
+  modality: string;
+  onChange: (value: string) => void;
+  color?: string;
+}
+
+const modalities = [
+  { value: 'text', label: 'Text' },
+  { value: 'audio', label: 'Audio' },
+  { value: 'visual', label: 'Visual' },
+];
+
+const ModalitySelector: React.FC<ModalitySelectorProps> = ({ modality, onChange, color = '#00FF00' }) => (
+  <select
+    value={modality}
+    onChange={e => onChange(e.target.value)}
+    className="bg-black border text-terminal-green px-2 py-1"
+    style={{ borderColor: color }}
+  >
+    {modalities.map(m => (
+      <option key={m.value} value={m.value} style={{ color: '#000' }}>
+        {m.label}
+      </option>
+    ))}
+  </select>
+);
+
+export default ModalitySelector;

--- a/apps/web/src/components/PageDisplay.tsx
+++ b/apps/web/src/components/PageDisplay.tsx
@@ -1,18 +1,31 @@
 import React from 'react';
 import { trpc } from '../utils/trpc';
+import ModalitySelector from './ModalitySelector';
 import type { Page } from '../../../packages/types/entrance-way';
 
 export interface PageDisplayProps {
   section?: number;
   index?: number;
   page?: Page | null;
+  modality?: string;
+  onModalityChange?: (value: string) => void;
   color?: string;
 }
 
-const PageDisplay: React.FC<PageDisplayProps> = ({ section, index, page, color = '#00FF00' }) => {
+const PageDisplay: React.FC<PageDisplayProps> = ({
+  section,
+  index,
+  page,
+  modality = 'text',
+  onModalityChange,
+  color = '#00FF00',
+}) => {
   // If page is not provided, fetch from API
   const { data, isLoading } = (!page && section && index)
-    ? trpc.getPageById.useQuery({ section, index })
+    ? trpc.getPageById.useQuery(
+        { section, index },
+        { context: { modality } },
+      )
     : { data: page, isLoading: false };
   const { data: metaList } = trpc.getSymbols.useQuery();
 
@@ -32,6 +45,15 @@ const PageDisplay: React.FC<PageDisplayProps> = ({ section, index, page, color =
       className="bg-black text-terminal-green p-4 border"
       style={{ borderColor: color }}
     >
+      {onModalityChange && (
+        <div className="mb-2">
+          <ModalitySelector
+            modality={modality}
+            onChange={onModalityChange}
+            color={color}
+          />
+        </div>
+      )}
       <h2 className="text-xl mb-2">
         Section {data.section} - {data.sectionName}
       </h2>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,11 +3,19 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { trpc } from './trpc';
 import { httpBatchLink } from '@trpc/client';
+import { getModality } from './utils/modalityStore';
 import './index.css';
 import App from './App';
 
 const client = trpc.createClient({
-  links: [httpBatchLink({ url: '/trpc' })],
+  links: [
+    httpBatchLink({
+      url: '/trpc',
+      headers: ({ op }) => ({
+        'x-modality': op.context?.modality ?? getModality(),
+      }),
+    }),
+  ],
 });
 
 const queryClient = new QueryClient();

--- a/apps/web/src/utils/modalityStore.ts
+++ b/apps/web/src/utils/modalityStore.ts
@@ -1,0 +1,7 @@
+let modality = 'text';
+
+export const setModality = (m: string) => {
+  modality = m;
+};
+
+export const getModality = () => modality;


### PR DESCRIPTION
## Summary
- add ModalitySelector component
- include selector inside PageDisplay and pass selected value via tRPC context
- propagate modality header in tRPC client
- update docs for the new selector

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test', integer primaryKey not a function)*
- `bun run pytest` *(fails: pytest not installed)*
- `bun run playwright:test` *(fails: ConnectionRefused downloading package manifest playwright)*