### PR TITLE
Add glyph codec tests

### DIFF
--- a/packages/utils/glyphCodec.ts
+++ b/packages/utils/glyphCodec.ts
@@ -1,0 +1,111 @@
+export enum Action {
+  Read = 0,
+  Index,
+  Prompt,
+  React,
+  Write,
+  Save,
+  Forget,
+  Dream,
+}
+
+export enum Context {
+  Page = 0,
+  Prompt,
+  Reaction,
+  Generation,
+}
+
+export enum State {
+  Public = 0,
+  Private,
+  Sacrifice,
+  Gift,
+}
+
+export enum Role {
+  Human = 0,
+  AI,
+  System,
+  Subsystem,
+}
+
+export enum Relation {
+  Subject = 0,
+  Object,
+}
+
+export enum Polarity {
+  Internal = 0,
+  External,
+}
+
+export enum Orientation {
+  N = 0,
+  E,
+  S,
+  W,
+}
+
+export enum Modality {
+  Text = 0,
+  Image,
+  Audio,
+  Video,
+}
+
+export interface GlyphAxes {
+  action: Action;
+  context: Context;
+  state: State;
+  role: Role;
+  relation: Relation;
+  polarity: Polarity;
+  orientation: Orientation;
+  modality: Modality;
+}
+
+export function encodeGlyph(
+  axes: Omit<Partial<GlyphAxes>, 'modality'> & {
+    action: Action;
+    context: Context;
+    state: State;
+    role: Role;
+    relation: Relation;
+    polarity: Polarity;
+    orientation: Orientation;
+    modality?: Modality;
+  }
+): string {
+  const full: GlyphAxes = {
+    modality: Modality.Text,
+    ...axes,
+  } as GlyphAxes;
+  const digits = [
+    full.action,
+    full.context,
+    full.state,
+    full.role,
+    full.relation,
+    full.polarity,
+    full.orientation,
+    full.modality,
+  ];
+  return digits.map((d) => d.toString(36)).join('');
+}
+
+export function decodeGlyph(code: string): GlyphAxes {
+  const digits = code.split('').map((ch) => parseInt(ch, 36));
+  const [action, context, state, role, relation, polarity, orientation, modality] = digits;
+  const mod = digits.length === 7 ? Modality.Text : (modality as Modality);
+  return {
+    action: action as Action,
+    context: context as Context,
+    state: state as State,
+    role: role as Role,
+    relation: relation as Relation,
+    polarity: polarity as Polarity,
+    orientation: orientation as Orientation,
+    modality: mod,
+  };
+}

--- a/tests/unit/glyphCodec.test.ts
+++ b/tests/unit/glyphCodec.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decodeGlyph,
+  encodeGlyph,
+  Action,
+  Context,
+  State,
+  Role,
+  Relation,
+  Polarity,
+  Orientation,
+  Modality,
+} from '../../packages/utils/glyphCodec';
+
+describe('glyphCodec', () => {
+  it('decodes 7-axis glyphs with default Text modality', () => {
+    const result = decodeGlyph('0123456');
+    expect(result).toEqual({
+      action: 0,
+      context: 1,
+      state: 2,
+      role: 3,
+      relation: 4,
+      polarity: 5,
+      orientation: 6,
+      modality: Modality.Text,
+    });
+  });
+
+  it('encodes and decodes video modality', () => {
+    const code = encodeGlyph({
+      action: Action.Read,
+      context: Context.Page,
+      state: State.Public,
+      role: Role.Human,
+      relation: Relation.Subject,
+      polarity: Polarity.Internal,
+      orientation: Orientation.N,
+      modality: Modality.Video,
+    });
+    const decoded = decodeGlyph(code);
+    expect(decoded).toEqual({
+      action: Action.Read,
+      context: Context.Page,
+      state: State.Public,
+      role: Role.Human,
+      relation: Relation.Subject,
+      polarity: Polarity.Internal,
+      orientation: Orientation.N,
+      modality: Modality.Video,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement glyph encode/decode logic
- test that old 7-axis glyphs decode as `Text`
- test encoding/decoding of `Modality.Video`

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test')*
- `pytest` *(fails: command not found)*