### PR TITLE
Document modality metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,15 @@
+# Ritual Metrics
+
+Gibsey tracks key interactions to understand how readers and agents move through the narrative. These ritual metrics cover everything from page views to how often a symbol appears.
+
+## Tracking Modality
+
+Metrics now record the medium of each Dream or ritual. When an event is logged, its modality is stored—text, audio, video, or interactive. For example, the system counts how many video Dreams occur during a session.
+
+## Impact on Narrative Branching
+
+Modality affects how branches unfold. A sequence with a high number of video Dreams might unlock multimedia paths, while text-only rituals keep the story in a prose-first mode. Agents use these counts to decide which narrative tools to employ and when to prompt the user for different types of engagement.
+
+## Influence on Agent Actions
+
+Agents reference these metrics to adjust their behavior. If a reader favors audio or video Dreams, agents prioritize those channels for hints or lore drops. The ledger of modalities helps maintain a balanced ritual experience and ensures new branches respect the preferred formats.


### PR DESCRIPTION
## Summary
- add `docs/metrics.md` describing ritual metrics
- explain how modality counts (like video Dreams) influence branching and agent behaviour

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test')*
- `pytest` *(fails: command not found)*
- `bunx playwright test` *(fails: command not found)*