### PR TITLE
Add QDPI action enum with encode/decode helpers

### DIFF
--- a/packages/types/qdpi/actions.ts
+++ b/packages/types/qdpi/actions.ts
@@ -1,0 +1,23 @@
+export enum Action {
+  Read,
+  Index,
+  Prompt,
+  React,
+  Write,
+  Save,
+  Forget,
+  Dream,
+  Link,
+  Merge
+}
+
+export function encodeAction(a: Action): number {
+  return a as number;
+}
+
+export function decodeAction(n: number): Action {
+  if (n in Action) {
+    return n as Action;
+  }
+  throw new RangeError(`Invalid action slot: ${n}`);
+}

--- a/tests/unit/actions.test.ts
+++ b/tests/unit/actions.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { Action, encodeAction, decodeAction } from '../../packages/types/qdpi/actions';
+
+describe('Action enum encode/decode', () => {
+  it('encodes actions to numeric slots', () => {
+    expect(encodeAction(Action.Read)).toBe(0);
+    expect(encodeAction(Action.Merge)).toBe(9);
+  });
+
+  it('decodes numeric slots to actions', () => {
+    expect(decodeAction(0)).toBe(Action.Read);
+    expect(decodeAction(9)).toBe(Action.Merge);
+  });
+
+  it('throws on invalid decode slot', () => {
+    expect(() => decodeAction(99)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- define `Action` enum under `packages/types/qdpi`
- provide `encodeAction` and `decodeAction` helpers
- cover the new utilities with unit tests

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' and Drizzle integer primaryKey function)*
- `pytest` *(fails: command not found)*