### PR TITLE
Expand QDPI action list

### DIFF
--- a/QDPI-spec.md
+++ b/QDPI-spec.md
@@ -12,12 +12,14 @@ Every possible interaction, state, and relation in the system is visible, progra
 
 ## II. THE MULTI-AXIS GRAMMAR: DIMENSIONS OF MEANING
 
-**QDPI-4096** is built on a **7-dimensional matrix**—every axis is a “layer” of grammar, a register of agency. Multiply them, and you get 4,096 possible “moves.”
+**QDPI-4096** is built on a **7-dimensional matrix**—every axis is a “layer” of grammar, a register of agency. Multiply them, and you get 10,240 possible “moves.”
 
-### 1. Actions (8):
+### 1. Actions (10):
 
-* **Read, Index, Prompt, React, Write, Save, Forget, Dream**
+* **Read, Index, Link, Prompt, React, Write, Save, Merge, Forget, Dream**
 
+  * **Link** connects pages or entire timelines so narratives can reference or jump across sections.
+  * **Merge** combines Vault artifacts, folding multiple drafts or branches into a unified page or timeline.
   * All forms of processing, transformation, memory, and creative production, for any subject or agent.
 
 ### 2. Contexts (4):
@@ -72,7 +74,7 @@ Every possible interaction, state, and relation in the system is visible, progra
 
 ### A. Encoding/Decoding
 
-* **4096 symbols = 8 × 4 × 4 × 4 × 2 × 2 × 4**
+* **10,240 symbols = 10 × 4 × 4 × 4 × 2 × 2 × 4**
 
   * Every glyph can be uniquely addressed and decoded as a full “move” or sentence.
 * **Bidirectionality:** All encodings are reversible, time-aware, and stateful.

--- a/the-QDPI-matrix.md
+++ b/the-QDPI-matrix.md
@@ -8,7 +8,7 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 
 | Axis (Dimension) | Options (How Many) | Examples/Notes                                                        |
 | ---------------- | ------------------ | --------------------------------------------------------------------- |
-| **Action**       | 8                  | Read, Index, Prompt, React, Write, Save, Forget, Dream                |
+| **Action**       | 10                 | Read, Index, Link (connect pages/timelines), Prompt, React, Write, Save, Merge (combine Vault artifacts), Forget, Dream |
 | **Context**      | 4                  | Page, Prompt/Query, Reaction/Draft, Generation                        |
 | **State/Parity** | 4                  | Public, Private, Sacrifice/Cost, Gift                                 |
 | **Role/Actor**   | 4                  | Human, AI/Character, Whole System, Part/System                        |
@@ -16,22 +16,25 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 | **Polarity**     | 2                  | Internal (“n”, Princhetta) / External (“u”, Cop-E-Right)              |
 | **Rotation**     | 4                  | N, E, S, W (0°, 90°, 180°, 270°)—perspective, sequencing, or “person” |
 
-**8 × 4 × 4 × 4 × 2 × 2 × 4 = 4096**
+**10 × 4 × 4 × 4 × 2 × 2 × 4 = 10,240**
 
 ---
 
 ## Matrix Slice: From Abstract to Concrete
 
-### 1. Action Layer (8)
+### 1. Action Layer (10)
 
-|                  | Read     | Index        | Prompt         | React       | Write | Save | Forget | Dream |
-| ---------------- | -------- | ------------ | -------------- | ----------- | ----- | ---- | ------ | ----- |
-| **Context** (4)  | Page     | Prompt/Query | Reaction/Draft | Generation  |       |      |        |       |
-| **State** (4)    | Public   | Private      | Sacrifice      | Gift        |       |      |        |       |
-| **Role** (4)     | Human    | AI           | Whole System   | Part/System |       |      |        |       |
-| **Relation** (2) | S→O      | O→S          |                |             |       |      |        |       |
-| **Polarity** (2) | Internal | External     |                |             |       |      |        |       |
-| **Rotation** (4) | N        | E            | S              | W           |       |      |        |       |
+|                  | Read     | Index        | Link           | Prompt      | React | Write | Save | Merge | Forget | Dream |
+| ---------------- | -------- | ------------ | -------------- | ----------- | ----- | ----- | ---- | ----- | ------ | ----- |
+| **Context** (4)  | Page     | Prompt/Query | Reaction/Draft | Generation  |       |      |       |       |       |       |
+| **State** (4)    | Public   | Private      | Sacrifice      | Gift        |       |      |       |       |       |       |
+| **Role** (4)     | Human    | AI           | Whole System   | Part/System |       |      |       |       |       |       |
+| **Relation** (2) | S→O      | O→S          |                |             |       |      |       |       |       |       |
+| **Polarity** (2) | Internal | External     |                |             |       |      |       |       |       |       |
+| **Rotation** (4) | N        | E            | S              | W           |       |      |       |       |       |       |
+
+* **Link** connects pages and timelines, forming explicit navigational paths across the Vault.
+* **Merge** combines artifacts from the Vault or different branches into a single coherent timeline or page.
 
 ---
 
@@ -83,7 +86,7 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 
 | Axes           | Options                                                   |
 | -------------- | --------------------------------------------------------- |
-| **Action**     | 8: Read, Index, Prompt, React, Write, Save, Forget, Dream |
+| **Action**     | 10: Read, Index, Link, Prompt, React, Write, Save, Merge, Forget, Dream |
 | **Context**    | 4: Page, Prompt/Query, Reaction/Draft, Generation         |
 | **State**      | 4: Public, Private, Sacrifice/Cost, Gift                  |
 | **Role/Actor** | 4: Human, AI, Whole System, Part/System                   |
@@ -91,7 +94,7 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 | **Polarity**   | 2: Internal (“n”/Princhetta), External (“u”/Cop-E-Right)  |
 | **Rotation**   | 4: N, E, S, W (0°, 90°, 180°, 270°)                       |
 
-**8 × 4 × 4 × 4 × 2 × 2 × 4 = 4096**
+**10 × 4 × 4 × 4 × 2 × 2 × 4 = 10,240**
 
 ---
 


### PR DESCRIPTION
## Summary
- include `Link` and `Merge` in the QDPI action list
- describe how Link connects pages and timelines and how Merge combines Vault artifacts
- update matrix table and totals for 10 actions (10,240 glyphs)

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test'; TypeError in drizzle ORM)*