### PR TITLE
Update QDPI roles

### DIFF
--- a/QDPI-spec.md
+++ b/QDPI-spec.md
@@ -12,7 +12,7 @@ Every possible interaction, state, and relation in the system is visible, progra
 
 ## II. THE MULTI-AXIS GRAMMAR: DIMENSIONS OF MEANING
 
-**QDPI-4096** is built on a **7-dimensional matrix**—every axis is a “layer” of grammar, a register of agency. Multiply them, and you get 4,096 possible “moves.”
+**QDPI-4096** is built on a **7-dimensional matrix**—every axis is a “layer” of grammar, a register of agency. Multiply them, and you get 6,144 possible “moves.”
 
 ### 1. Actions (8):
 
@@ -32,11 +32,12 @@ Every possible interaction, state, and relation in the system is visible, progra
 
   * “How” the move is situated—who sees it, how it is valued or exchanged, whether it is open or closed, offered or reserved.
 
-### 4. Roles/Actors (4):
+### 4. Roles/Actors (6):
 
-* **Human, AI (Character), Whole System, Part/System**
+* **Human, AI (Character), Guest, Mythic Guardian, Whole System, Part/System**
 
   * Who is acting or being acted upon; who originates or receives; allows full mirroring of user, agent, meta-agent, subsystem.
+  * The **Guest** is a temporary user with minimal persistence. The **Mythic Guardian** acts as a narrative moderator, ensuring coherence and protecting the story world.
 
 ### 5. Relation (2):
 
@@ -72,7 +73,7 @@ Every possible interaction, state, and relation in the system is visible, progra
 
 ### A. Encoding/Decoding
 
-* **4096 symbols = 8 × 4 × 4 × 4 × 2 × 2 × 4**
+* **6,144 symbols = 8 × 4 × 4 × 6 × 2 × 2 × 4**
 
   * Every glyph can be uniquely addressed and decoded as a full “move” or sentence.
 * **Bidirectionality:** All encodings are reversible, time-aware, and stateful.

--- a/the-QDPI-matrix.md
+++ b/the-QDPI-matrix.md
@@ -11,12 +11,14 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 | **Action**       | 8                  | Read, Index, Prompt, React, Write, Save, Forget, Dream                |
 | **Context**      | 4                  | Page, Prompt/Query, Reaction/Draft, Generation                        |
 | **State/Parity** | 4                  | Public, Private, Sacrifice/Cost, Gift                                 |
-| **Role/Actor**   | 4                  | Human, AI/Character, Whole System, Part/System                        |
+| **Role/Actor**   | 6                  | Human, AI/Character, Guest, Mythic Guardian, Whole System, Part/System |
 | **Relation**     | 2                  | Subject→Object, Object→Subject (initiator/responder)                  |
 | **Polarity**     | 2                  | Internal (“n”, Princhetta) / External (“u”, Cop-E-Right)              |
 | **Rotation**     | 4                  | N, E, S, W (0°, 90°, 180°, 270°)—perspective, sequencing, or “person” |
 
-**8 × 4 × 4 × 4 × 2 × 2 × 4 = 4096**
+The **Guest** role represents a temporary user with minimal persistence. The **Mythic Guardian** serves as a narrative moderator, protecting coherence within the story.
+
+**8 × 4 × 4 × 6 × 2 × 2 × 4 = 6,144**
 
 ---
 
@@ -28,7 +30,7 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 | ---------------- | -------- | ------------ | -------------- | ----------- | ----- | ---- | ------ | ----- |
 | **Context** (4)  | Page     | Prompt/Query | Reaction/Draft | Generation  |       |      |        |       |
 | **State** (4)    | Public   | Private      | Sacrifice      | Gift        |       |      |        |       |
-| **Role** (4)     | Human    | AI           | Whole System   | Part/System |       |      |        |       |
+| **Role** (6)     | Human    | AI           | Guest          | Mythic Guardian | Whole System   | Part/System |       |       |
 | **Relation** (2) | S→O      | O→S          |                |             |       |      |        |       |
 | **Polarity** (2) | Internal | External     |                |             |       |      |        |       |
 | **Rotation** (4) | N        | E            | S              | W           |       |      |        |       |
@@ -86,12 +88,12 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 | **Action**     | 8: Read, Index, Prompt, React, Write, Save, Forget, Dream |
 | **Context**    | 4: Page, Prompt/Query, Reaction/Draft, Generation         |
 | **State**      | 4: Public, Private, Sacrifice/Cost, Gift                  |
-| **Role/Actor** | 4: Human, AI, Whole System, Part/System                   |
+| **Role/Actor** | 6: Human, AI, Guest, Mythic Guardian, Whole System, Part/System |
 | **Relation**   | 2: Subject→Object, Object→Subject                         |
 | **Polarity**   | 2: Internal (“n”/Princhetta), External (“u”/Cop-E-Right)  |
 | **Rotation**   | 4: N, E, S, W (0°, 90°, 180°, 270°)                       |
 
-**8 × 4 × 4 × 4 × 2 × 2 × 4 = 4096**
+**8 × 4 × 4 × 6 × 2 × 2 × 4 = 6,144**
 
 ---
 


### PR DESCRIPTION
## Summary
- document the new roles Guest and Mythic Guardian
- expand role lists from four to six
- update glyph count to 6,144

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test')*
- `pytest` *(fails: command not found)*
- `bunx playwright test` *(fails: command not found)*