### PR TITLE
Add role permissions documentation and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,8 @@ newer), and **Python 3** installed.
 Run the TypeScript unit tests with `bun test`. Python tests are executed with `pytest`.
 
 ---
+
+## Roles and Permissions
+
+See [docs/role-permissions.md](docs/role-permissions.md) for allowed actions of Guests, Scribes, Contributors, and Guardians.
+

--- a/agents.md
+++ b/agents.md
@@ -212,7 +212,7 @@ tests expect this path during setup.
 ---
 
 ## Need Help?  
-- Check `/README.md` and `/docs/`
+- Check `/README.md`, `/docs/`, and [`docs/role-permissions.md`](docs/role-permissions.md)
 - For environment or deployment issues, see `coolify.yml` and Docker configs.
 - For AI/ML questions, see `/services/ai/README.md`
 - Ask, don’t guess — leave issues or notes for future agents.

--- a/docs/role-permissions.md
+++ b/docs/role-permissions.md
@@ -1,0 +1,12 @@
+# Role Permissions
+
+This document defines the basic capabilities granted to each user role within the Gibsey platform.
+
+| Role       | Allowed Actions |
+|-----------|----------------|
+| **Guest** | Read pages, browse symbols, react with emojis |
+| **Scribe** | All Guest actions plus comment on pages and create drafts |
+| **Contributor** | All Scribe actions plus open pull requests and manage personal branches |
+| **Guardian** | Full Contributor rights plus approve merges and manage roles |
+
+These permissions are intentionally lightweight. More granular capabilities can be layered in the API as the project evolves.

--- a/packages/types/roles.ts
+++ b/packages/types/roles.ts
@@ -1,0 +1,10 @@
+export type Role = 'Guest' | 'Scribe' | 'Contributor' | 'Guardian';
+
+export type RoleCapabilities = Record<Role, string[]>;
+
+export const roleCapabilities: RoleCapabilities = {
+  Guest: ['read', 'react'],
+  Scribe: ['read', 'react', 'comment', 'draft'],
+  Contributor: ['read', 'react', 'comment', 'draft', 'pull'],
+  Guardian: ['read', 'react', 'comment', 'draft', 'pull', 'approve'],
+};


### PR DESCRIPTION
## Summary
- document permissions for Guest, Scribe, Contributor and Guardian roles
- link new doc from README and AGENTS onboarding
- add `RoleCapabilities` type with sample capabilities map

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' & Drizzle integer function error)*