### PR TITLE
Add role-based middleware and sample procedure

### DIFF
--- a/apps/api/src/middleware/requireRole.ts
+++ b/apps/api/src/middleware/requireRole.ts
@@ -1,0 +1,13 @@
+import { t } from '../trpc';
+import { permissionsMap } from '../../../../packages/types/permissions';
+
+// Middleware enforcing role-based permissions using ctx.user.role.
+// Refer to the permissions map in packages/types for allowed actions.
+export const requireRole = (allowed: string[]) =>
+  t.middleware(({ ctx, next }) => {
+    const role = (ctx.user as any)?.role;
+    if (!role || !allowed.includes(role)) {
+      throw new Error('Forbidden');
+    }
+    return next();
+  });

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1,5 +1,4 @@
 import { Hono } from 'hono';
-import { initTRPC } from '@trpc/server';
 import type { Context } from 'hono';
 import { trpcServer } from '@hono/trpc-server';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
@@ -12,11 +11,10 @@ import { authMiddleware } from '../auth/middleware';
 import colorMap from '../../../the-corpus/colors';
 import { join } from 'path';
 import { readdirSync } from 'fs';
+import { t, AppContext } from './trpc';
+import { requireRole } from './middleware/requireRole';
 
 export const db = drizzle(new Database('db.sqlite'));
-
-export type AppContext = Context & { user: unknown };
-const t = initTRPC.context<AppContext>().create();
 
 const pageSelect = {
   id: pages.id,
@@ -103,6 +101,14 @@ export const appRouter = t.router({
   getCorpusMetadata: t.procedure.query(async () => {
     return { colors: colorMap };
   }),
+
+  mergeEntries: t.procedure
+    .use(requireRole(['MythicGuardian']))
+    .input(z.object({ sourceId: z.number(), targetId: z.number() }))
+    .mutation(async () => {
+      // placeholder merge logic; see permissionsMap in packages/types
+      return { success: true };
+    }),
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/api/src/trpc.ts
+++ b/apps/api/src/trpc.ts
@@ -1,0 +1,6 @@
+import { initTRPC } from '@trpc/server';
+import type { Context } from 'hono';
+
+export type AppContext = Context & { user: unknown };
+
+export const t = initTRPC.context<AppContext>().create();

--- a/packages/types/permissions.ts
+++ b/packages/types/permissions.ts
@@ -1,0 +1,7 @@
+export type UserRole = 'MythicGuardian' | 'Scribe' | 'Visitor';
+
+export const permissionsMap: Record<UserRole, string[]> = {
+  MythicGuardian: ['mergeEntries'],
+  Scribe: [],
+  Visitor: [],
+};

--- a/tests/unit/api/merge-entries.test.ts
+++ b/tests/unit/api/merge-entries.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as bunTest from 'bun:test';
+
+if (!('mock' in vi)) {
+  (vi as any).mock = (bunTest as any).mock;
+}
+
+vi.mock('hono', () => ({ Hono: class {} }));
+vi.mock('@hono/trpc-server', () => ({ trpcServer: () => {} }));
+vi.mock('drizzle-orm/bun-sqlite', () => ({ drizzle: () => ({}) }));
+vi.mock('bun:sqlite', () => ({ Database: class {} }));
+vi.mock('drizzle-orm/sqlite-core', () => ({
+  sqliteTable: () => ({}),
+  integer: () => ({ primaryKey: () => ({}) }),
+  text: () => ({ notNull: () => ({}) })
+}));
+vi.mock('../../../packages/db/src/schema', () => ({ pages: {}, sections: {} }));
+vi.mock('@trpc/server', () => ({
+  initTRPC: () => ({
+    context: () => ({
+      create: () => {
+        const chain: any = {};
+        chain.input = () => chain;
+        chain.use = () => chain;
+        chain.query = (fn: any) => (input: any) => fn({ input } as any);
+        chain.mutation = (fn: any) => (input: any) => fn({ input } as any);
+        return {
+          router: (obj: any) => ({ ...obj, createCaller: () => obj }),
+          middleware: (fn: any) => fn,
+          procedure: chain,
+        };
+      }
+    })
+  })
+}));
+vi.mock('drizzle-orm', () => ({ eq: () => ({}), and: () => ({}), like: () => ({}) }));
+vi.mock('../../../apps/api/auth/middleware', () => ({ authMiddleware: () => {} }));
+vi.mock('../../../the-corpus/symbols/metadata', () => ({ symbolMetadata: [] }));
+vi.mock('../../../packages/db/src/schema.ts', () => ({ pages: {}, sections: {} }));
+
+import * as router from '../../../apps/api/src/router';
+
+describe('mergeEntries', () => {
+  it('allows MythicGuardian role', async () => {
+    const caller = router.appRouter.createCaller({ user: { role: 'MythicGuardian' } } as any);
+    const result = await caller.mergeEntries({ sourceId: 1, targetId: 2 });
+    expect(result).toEqual({ success: true });
+  });
+
+  it('rejects other roles', async () => {
+    const caller = router.appRouter.createCaller({ user: { role: 'Scribe' } } as any);
+    await expect(caller.mergeEntries({ sourceId: 1, targetId: 2 })).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add permissions map for user roles
- enforce role permissions with new `requireRole` middleware
- refactor TRPC context into its own module
- restrict new `mergeEntries` procedure to `MythicGuardian`
- add unit test for the role middleware

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' and schema mocks)*
- `pytest` *(fails: command not found)*
- `bun x playwright test` *(fails: network access needed)*