### PR TITLE
Add role badge component

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,12 +5,16 @@ import PageDisplay from './components/PageDisplay';
 import SearchJump from './components/SearchJump';
 import SymbolFilter from './components/SymbolFilter';
 import ColorFilter from './components/ColorFilter';
+import RoleBadge from './components/RoleBadge';
 
 const App: React.FC = () => {
   const [section, setSection] = useState(1);
   const [index, setIndex] = useState(1);
   const { data: sections } = trpc.getSections.useQuery();
   const page = trpc.getPageById.useQuery({ section, index });
+
+  // Temporary user data until auth is implemented
+  const user = { name: 'Guest', role: 'guest' as const };
 
   const currentColor =
     sections?.find((s) => s.id === section)?.color ?? '#00FF00';
@@ -22,6 +26,13 @@ const App: React.FC = () => {
 
   return (
     <div className="space-y-4 border p-4" data-testid="app-root" style={{ borderColor: currentColor }}>
+      <header className="flex items-center justify-between mb-4">
+        <h1 className="text-xl">Gibsey</h1>
+        <div className="flex items-center gap-2">
+          <span>{user.name}</span>
+          <RoleBadge role={user.role} />
+        </div>
+      </header>
       <Navigation
         section={section}
         index={index}

--- a/apps/web/src/components/RoleBadge.tsx
+++ b/apps/web/src/components/RoleBadge.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { roleStyles } from '../utils/roleStyles';
+
+export interface RoleBadgeProps {
+  role: keyof typeof roleStyles;
+}
+
+const RoleBadge: React.FC<RoleBadgeProps> = ({ role }) => {
+  const style = roleStyles[role] ?? roleStyles.guest;
+
+  return (
+    <span
+      className="inline-flex items-center gap-1 px-2 py-1 border rounded"
+      style={{ borderColor: style.color }}
+    >
+      <span>{style.icon}</span>
+      <span>{role}</span>
+    </span>
+  );
+};
+
+export default RoleBadge;
+

--- a/apps/web/src/utils/roleStyles.ts
+++ b/apps/web/src/utils/roleStyles.ts
@@ -1,0 +1,10 @@
+export interface RoleStyle {
+  color: string;
+  icon: string;
+}
+
+export const roleStyles: Record<string, RoleStyle> = {
+  mythicGuardian: { color: '#FFD700', icon: '🛡' },
+  guest: { color: '#888888', icon: '⋯' },
+};
+


### PR DESCRIPTION
## Summary
- add role style constants for front-end UI
- show a `RoleBadge` near the temporary user name in the web app header

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' & drizzle setup issues)*