### PR TITLE
Add role permission examples

### DIFF
--- a/docs/role-permissions.md
+++ b/docs/role-permissions.md
@@ -1,0 +1,24 @@
+# Role Permissions Examples
+
+This short document captures sample events for the Vault logging system. Once Vault logging is implemented, these examples can be referenced in test comments.
+
+## Guest reaction example
+
+```json
+{
+  "action": "React",
+  "role": "Guest"
+}
+```
+
+## Mythic Guardian merge approval example
+
+```json
+{
+  "action": "Save",
+  "role": "MythicGuardian",
+  "approval": true
+}
+```
+
+These snippets will be referenced by unit tests when Vault logging is built.


### PR DESCRIPTION
## Summary
- document example JSON objects for Vault logging

## Testing
- `bun test` *(fails: cannot find module '@playwright/test' and Drizzle schema errors)*
- `pytest` *(fails: command not found)*