### PR TITLE
Add Guests & Guardians roles

### DIFF
--- a/docs/implementation-plan/implementation-plan-overview.md
+++ b/docs/implementation-plan/implementation-plan-overview.md
@@ -38,6 +38,7 @@ This file summarizes the staged implementation plan for building Gibsey’s nine
 **Tasks:**
 
 * Define QDPI schema/protocol (including user/agent roles).
+* Introduce role tiers: **Mythic Guardians** to oversee merges and **Guests** for ephemeral interactions.
 * Build initial API endpoints/message handlers for QDPI actions.
 * Wire into Entrance Way, Corpus, and Vault for recursion test.
 * Document for agents and plugins in AGENTS.md.

--- a/the-QDPI-matrix.md
+++ b/the-QDPI-matrix.md
@@ -95,6 +95,13 @@ Below is the *generative matrix* for QDPI‑4096—**every “cell” is a uniqu
 
 ---
 
+## Guests & Mythic Guardians
+
+* **Mythic Guardians** oversee merges and major protocol rituals. They review glyph flows and grant final approval before a branch joins the living matrix.
+* **Guests** participate only ephemerally. They may read, prompt, or dream but cannot make lasting changes without a Guardian's blessing.
+
+---
+
 **Every cell is a glyph. Every glyph is a move. Every move is a story, an action, a protocol event, a ritual, or a memory.**
 
 **QDPI-4096: The matrix is alive.**


### PR DESCRIPTION
## Summary
- describe how Guests and Mythic Guardians engage with QDPI rituals
- outline role tiers in the implementation plan

## Testing
- `bun test` *(fails: Cannot find module `@playwright/test` and other issues)*
- `pytest` *(fails: command not found)*
- `bunx playwright test` *(fails: command not found)*