### PR TITLE
Add dream logging to Vault

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -4,7 +4,7 @@ import type { Context } from 'hono';
 import { trpcServer } from '@hono/trpc-server';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
-import { pages, sections } from '../../../packages/db/src/schema';
+import { pages, sections, vaultEntries } from '../../../packages/db/src/schema';
 import { symbolMetadata } from '../../../the-corpus/symbols/metadata';
 import { eq, and, like } from 'drizzle-orm';
 import { z } from 'zod';
@@ -99,6 +99,36 @@ export const appRouter = t.router({
     const files = readdirSync(dir);
     return files.filter((f) => f.endsWith('.svg'));
   }),
+
+  logDream: t.procedure
+    .input(
+      z.object({
+        action: z.string(),
+        context: z.string(),
+        state: z.string(),
+        role: z.string(),
+        relation: z.string(),
+        polarity: z.string(),
+        rotation: z.string(),
+        content: z.string(),
+        actorId: z.string(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      await db.insert(vaultEntries).values({
+        action: input.action,
+        context: input.context,
+        state: input.state,
+        role: input.role,
+        relation: input.relation,
+        polarity: input.polarity,
+        rotation: input.rotation,
+        content: input.content,
+        actorId: input.actorId,
+        createdAt: Date.now(),
+      });
+      return { success: true };
+    }),
 
   getCorpusMetadata: t.procedure.query(async () => {
     return { colors: colorMap };

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,8 +9,15 @@ import ColorFilter from './components/ColorFilter';
 const App: React.FC = () => {
   const [section, setSection] = useState(1);
   const [index, setIndex] = useState(1);
+  const [dreamToast, setDreamToast] = useState(false);
   const { data: sections } = trpc.getSections.useQuery();
   const page = trpc.getPageById.useQuery({ section, index });
+  const logDream = trpc.logDream.useMutation({
+    onSuccess: () => {
+      setDreamToast(true);
+      setTimeout(() => setDreamToast(false), 2000);
+    },
+  });
 
   const currentColor =
     sections?.find((s) => s.id === section)?.color ?? '#00FF00';
@@ -41,7 +48,31 @@ const App: React.FC = () => {
           }}
           color={currentColor}
         />
+        <button
+          onClick={() =>
+            logDream.mutate({
+              action: 'Dream',
+              context: 'ui',
+              state: 'awake',
+              role: 'reader',
+              relation: 'self',
+              polarity: 'neutral',
+              rotation: 'N',
+              content: page.data?.text ?? '',
+              actorId: 'anon',
+            })
+          }
+          className="border px-2 py-1"
+          style={{ borderColor: currentColor }}
+        >
+          Dream
+        </button>
       </div>
+      {dreamToast && (
+        <div className="text-terminal-green" data-testid="dream-toast">
+          Dream captured in Vault
+        </div>
+      )}
     </div>
   );
 };

--- a/drizzle/0002_create_vault_entries.sql
+++ b/drizzle/0002_create_vault_entries.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS vault_entries (
+  id INTEGER PRIMARY KEY,
+  action TEXT NOT NULL,
+  context TEXT NOT NULL,
+  state TEXT NOT NULL,
+  role TEXT NOT NULL,
+  relation TEXT NOT NULL,
+  polarity TEXT NOT NULL,
+  rotation TEXT NOT NULL,
+  content TEXT NOT NULL,
+  actor_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -17,6 +17,20 @@ export const pages = sqliteTable('pages', {
   text: text('text').notNull(),
 });
 
+export const vaultEntries = sqliteTable('vault_entries', {
+  id: integer('id').primaryKey(),
+  action: text('action').notNull(),
+  context: text('context').notNull(),
+  state: text('state').notNull(),
+  role: text('role').notNull(),
+  relation: text('relation').notNull(),
+  polarity: text('polarity').notNull(),
+  rotation: text('rotation').notNull(),
+  content: text('content').notNull(),
+  actorId: text('actor_id').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+});
+
 export const sectionRelations = relations(sections, ({ many }) => ({
   pages: many(pages),
 }));

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -9,3 +9,7 @@ Common TypeScript types and interfaces shared across the Gibsey project.
 - `GetPageByIdParams`, `GetPagesBySectionParams`, `SearchPagesParams` – input shapes for the API procedures.
 - `GetPageByIdResult`, `GetPagesBySectionResult`, `SearchPagesResult` – return types from the API.
 
+
+### Vault Entries
+
+`vault.ts` defines the `VaultEntry` interface representing a logged dream or other QDPI event stored in the database.

--- a/packages/types/vault.ts
+++ b/packages/types/vault.ts
@@ -1,0 +1,13 @@
+export interface VaultEntry {
+  id: number;
+  action: string;
+  context: string;
+  state: string;
+  role: string;
+  relation: string;
+  polarity: string;
+  rotation: string;
+  content: string;
+  actorId: string;
+  createdAt: number;
+}

--- a/services/ai/test_agent.py
+++ b/services/ai/test_agent.py
@@ -29,11 +29,30 @@ def post_fake_comment(page_id: int, text: str):
     logging.info("Posting fake comment to page %s: %s", page_id, text)
 
 
+def log_dream(content: str, actor_id: str = "test_agent"):
+    """Log a dream move via the tRPC API."""
+    payload = {
+        "input": {
+            "action": "Dream",
+            "context": "test",
+            "state": "awake",
+            "role": "tester",
+            "relation": "self",
+            "polarity": "neutral",
+            "rotation": "N",
+            "content": content,
+            "actorId": actor_id,
+        }
+    }
+    requests.post(f"{API_BASE}/trpc/logDream", json=payload, timeout=5)
+
+
 def main():
     page = fetch_page(1, 1)
     if page:
         logging.info("Page text: %s", page.get('text'))
         post_fake_comment(page.get('id', 0), "Test comment from test_agent")
+        log_dream(page.get('text', ''), "test_agent")
     else:
         logging.warning("Page not found")
 

--- a/tests/unit/api/entrance-way.test.ts
+++ b/tests/unit/api/entrance-way.test.ts
@@ -16,7 +16,7 @@ vi.mock('drizzle-orm/sqlite-core', () => ({
   integer: () => ({ primaryKey: () => ({}) }),
   text: () => ({ notNull: () => ({}) })
 }));
-vi.mock('../../../packages/db/src/schema', () => ({ pages: {}, sections: {} }));
+vi.mock('../../../packages/db/src/schema', () => ({ pages: {}, sections: {}, vaultEntries: {} }));
 vi.mock('@trpc/server', () => ({ initTRPC: () => ({ context: () => ({ create: () => ({ router: (obj: any) => obj }) }) }) }));
 vi.mock('drizzle-orm', () => ({ eq: () => ({}), and: () => ({}), like: () => ({}) }));
 vi.mock('../../../apps/api/auth/middleware', () => ({ authMiddleware: () => {} }));
@@ -25,7 +25,7 @@ vi.mock('../../../apps/api/auth/middleware', () => ({ authMiddleware: () => {} }
 vi.mock('../../../the-corpus/symbols/metadata', () => ({
   symbolMetadata: [{ character: 'Test', filename: 'a.svg', color: '#fff', orientation: 'upright' }],
 }));
-vi.mock('../../../packages/db/src/schema.ts', () => ({ pages: {}, sections: {} }));
+vi.mock('../../../packages/db/src/schema.ts', () => ({ pages: {}, sections: {}, vaultEntries: {} }));
 
 import * as router from '../../../apps/api/src/router';
 

--- a/tests/unit/api/vault.test.ts
+++ b/tests/unit/api/vault.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as bunTest from 'bun:test';
+
+if (!('mock' in vi)) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (vi as any).mock = (bunTest as any).mock;
+}
+
+vi.mock('hono', () => ({ Hono: class {} }));
+vi.mock('@hono/trpc-server', () => ({ trpcServer: () => {} }));
+vi.mock('drizzle-orm/bun-sqlite', () => ({ drizzle: () => ({}) }));
+vi.mock('bun:sqlite', () => ({ Database: class {} }));
+vi.mock('drizzle-orm/sqlite-core', () => ({
+  sqliteTable: () => ({}),
+  integer: () => ({ primaryKey: () => ({}) }),
+  text: () => ({ notNull: () => ({}) })
+}));
+vi.mock('../../../packages/db/src/schema', () => ({ pages: {}, sections: {}, vaultEntries: {} }));
+vi.mock('@trpc/server', () => ({ initTRPC: () => ({ context: () => ({ create: () => ({ router: (obj: any) => obj }) }) }) }));
+vi.mock('drizzle-orm', () => ({}));
+vi.mock('../../../apps/api/auth/middleware', () => ({ authMiddleware: () => {} }));
+vi.mock('../../../the-corpus/symbols/metadata', () => ({ symbolMetadata: [] }));
+
+import * as router from '../../../apps/api/src/router';
+
+const mockDb = {
+  insert: vi.fn().mockReturnThis(),
+  values: vi.fn().mockReturnThis(),
+};
+
+beforeEach(() => {
+  router.db.insert = mockDb.insert as any;
+  router.db.values = mockDb.values as any;
+});
+
+describe('logDream', () => {
+  it('creates a vault entry', async () => {
+    const caller = router.appRouter.createCaller({ user: null } as any);
+    await caller.logDream({
+      action: 'Dream',
+      context: 'test',
+      state: 'awake',
+      role: 'tester',
+      relation: 'self',
+      polarity: 'neutral',
+      rotation: 'N',
+      content: 'hello',
+      actorId: 'tester',
+    });
+    expect(mockDb.insert).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `vault_entries` table to DB schema
- provide VaultEntry types
- implement `logDream` procedure
- call `logDream` from test agent
- show a toast in the React UI when dreaming
- cover `logDream` with unit tests
- create DB migration for new table

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' and other test failures)*
- `pytest` *(fails: command not found)*
- `bunx playwright test` *(fails: command not found)*