### PR TITLE
Add Vault replay and metrics features

### DIFF
--- a/apps/api/src/metrics.ts
+++ b/apps/api/src/metrics.ts
@@ -1,0 +1,16 @@
+export const metrics = {
+  dreamsLoggedTotal: 0,
+  dreamGiftsRecent: 0,
+};
+
+export function recordDream(state: string) {
+  metrics.dreamsLoggedTotal += 1;
+  if (state === 'gift') {
+    metrics.dreamGiftsRecent += 1;
+  }
+}
+
+export function resetMetrics() {
+  metrics.dreamsLoggedTotal = 0;
+  metrics.dreamGiftsRecent = 0;
+}

--- a/apps/web/src/components/Dashboard.tsx
+++ b/apps/web/src/components/Dashboard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { trpc } from '../utils/trpc';
+
+const Dashboard: React.FC = () => {
+  const { data, isLoading } = trpc.getMetrics.useQuery();
+
+  if (isLoading || !data) {
+    return <div className="bg-black text-terminal-green p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="bg-black text-terminal-green p-4 border" style={{ borderColor: '#00FF00' }}>
+      <h2 className="text-xl mb-2">Dream Metrics</h2>
+      <div>Total Dreams Logged: {data.dreamsLoggedTotal}</div>
+      <div>Recent Dream Gifts: {data.dreamGiftsRecent}</div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/drizzle/0002_create_vault_entries.sql
+++ b/drizzle/0002_create_vault_entries.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS vault_entries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  actor_id TEXT NOT NULL,
+  state TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_vault_actor ON vault_entries(actor_id);
+CREATE INDEX IF NOT EXISTS idx_vault_created ON vault_entries(created_at);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, integer, text, index } from 'drizzle-orm/sqlite-core';
 import { relations } from 'drizzle-orm';
 
 export const sections = sqliteTable('sections', {
@@ -27,3 +27,18 @@ export const pageRelations = relations(pages, ({ one }) => ({
     references: [sections.id],
   }),
 }));
+
+export const vaultEntries = sqliteTable(
+  'vault_entries',
+  {
+    id: integer('id').primaryKey(),
+    actorId: text('actor_id').notNull(),
+    state: text('state').notNull(),
+    content: text('content').notNull(),
+    createdAt: integer('created_at').notNull(),
+  },
+  (t) => ({
+    actorIdx: index('idx_vault_actor').on(t.actorId),
+    createdIdx: index('idx_vault_created').on(t.createdAt),
+  })
+);

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -9,3 +9,7 @@ Common TypeScript types and interfaces shared across the Gibsey project.
 - `GetPageByIdParams`, `GetPagesBySectionParams`, `SearchPagesParams` – input shapes for the API procedures.
 - `GetPageByIdResult`, `GetPagesBySectionResult`, `SearchPagesResult` – return types from the API.
 
+
+### Vault
+
+`vault.ts` defines interfaces for entries stored in the Vault and related procedure params.

--- a/packages/types/vault.ts
+++ b/packages/types/vault.ts
@@ -1,0 +1,20 @@
+export interface VaultEntry {
+  id: number;
+  actorId: string;
+  state: string;
+  content: string;
+  createdAt: number;
+}
+
+export interface LogDreamParams {
+  actorId: string;
+  state: string;
+  content: string;
+}
+
+export interface ReplayDreamsParams {
+  actorId?: string;
+  start?: number;
+  end?: number;
+  state?: string;
+}

--- a/tests/unit/api/vault.test.ts
+++ b/tests/unit/api/vault.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as router from '../../../apps/api/src/router';
+import { metrics, resetMetrics } from '../../../apps/api/src/metrics';
+
+const records: any[] = [];
+
+const mockDb = {
+  insert: vi.fn(() => ({
+    values: vi.fn(async (val) => {
+      records.push({ id: records.length + 1, ...val });
+    }),
+  })),
+  select: vi.fn(() => ({
+    from: vi.fn(async () => records),
+  })),
+};
+
+beforeEach(() => {
+  records.length = 0;
+  resetMetrics();
+  router.db.insert = mockDb.insert as any;
+  router.db.select = mockDb.select as any;
+});
+
+describe('logDream and replayDreams', () => {
+  it('increments metrics on logDream', async () => {
+    const caller = router.appRouter.createCaller({ user: null } as any);
+    await caller.logDream({ actorId: 'a', state: 'dream', content: 'one' });
+    await caller.logDream({ actorId: 'b', state: 'gift', content: 'two' });
+    expect(metrics.dreamsLoggedTotal).toBe(2);
+    expect(metrics.dreamGiftsRecent).toBe(1);
+  });
+
+  it('filters replayDreams correctly', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const caller = router.appRouter.createCaller({ user: null } as any);
+    await caller.logDream({ actorId: 'a', state: 'dream', content: 'one' });
+    vi.setSystemTime(2000);
+    await caller.logDream({ actorId: 'b', state: 'gift', content: 'two' });
+
+    const all = await caller.replayDreams({});
+    expect(all.length).toBe(2);
+
+    const byActor = await caller.replayDreams({ actorId: 'a' });
+    expect(byActor.length).toBe(1);
+
+    const byState = await caller.replayDreams({ state: 'gift' });
+    expect(byState[0].actorId).toBe('b');
+
+    const byDate = await caller.replayDreams({ start: 1500 });
+    expect(byDate.length).toBe(1);
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- create Vault entries table and migrations
- add metrics module for tracking logged dreams
- implement `logDream`, `replayDreams`, and `getMetrics` procedures
- expose metrics in new Dashboard component
- add vault related types
- test dream logging, metrics, and filtering

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test')*
- `pytest` *(fails: command not found)*
- `bunx playwright test` *(fails: bunx not found)*