### PR TITLE
Add Gate messaging primitives

### DIFF
--- a/packages/db/src/schema.js
+++ b/packages/db/src/schema.js
@@ -1,2 +1,3 @@
 export const pages = {};
 export const sections = {};
+export const vaultEntries = {};

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -27,3 +27,12 @@ export const pageRelations = relations(pages, ({ one }) => ({
     references: [sections.id],
   }),
 }));
+export const vaultEntries = sqliteTable('vault_entries', {
+  id: integer('id').primaryKey(),
+  messageId: text('message_id').notNull().unique(),
+  context: text('context').notNull(),
+  fromWorld: text('from_world').notNull(),
+  toWorld: text('to_world').notNull(),
+  payload: text('payload').notNull(),
+  orientation: text('orientation').notNull(),
+});

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -9,3 +9,7 @@ Common TypeScript types and interfaces shared across the Gibsey project.
 - `GetPageByIdParams`, `GetPagesBySectionParams`, `SearchPagesParams` – input shapes for the API procedures.
 - `GetPageByIdResult`, `GetPagesBySectionResult`, `SearchPagesResult` – return types from the API.
 
+
+### Gate Messages
+
+`gate.ts` defines the `GateMessage` interface for Mycelial Narrative Relay communications. It includes all QDPI axes along with cross‑world metadata (`fromWorld`, `toWorld`, `payload`, and `orientation`).

--- a/packages/types/gate.ts
+++ b/packages/types/gate.ts
@@ -1,0 +1,21 @@
+export type QDPIAction = 'Read' | 'Index' | 'Prompt' | 'React' | 'Write' | 'Save' | 'Forget' | 'Dream';
+export type QDPIContext = 'Page' | 'Prompt/Query' | 'Reaction/Draft' | 'Generation';
+export type QDPIState = 'Public' | 'Private' | 'Sacrifice' | 'Gift';
+export type QDPIRole = 'Human' | 'AI' | 'System' | 'Part';
+export type QDPIRelation = 'SubjectToObject' | 'ObjectToSubject';
+export type QDPIPolarity = 'Internal' | 'External';
+export type QDPIOrientation = 'N' | 'E' | 'S' | 'W';
+
+export interface GateMessage {
+  id: string;
+  action: QDPIAction;
+  context: QDPIContext;
+  state: QDPIState;
+  role: QDPIRole;
+  relation: QDPIRelation;
+  polarity: QDPIPolarity;
+  orientation: QDPIOrientation;
+  fromWorld: string;
+  toWorld: string;
+  payload: unknown;
+}

--- a/services/mnr/gate.ts
+++ b/services/mnr/gate.ts
@@ -1,0 +1,50 @@
+import type { GateMessage } from '../../packages/types/gate';
+
+export type GateDB = {
+  insert: (table: unknown) => { values: (data: unknown) => Promise<unknown> };
+};
+
+export type GateHandler = (msg: GateMessage) => Promise<void> | void;
+
+export function createGate(db: GateDB, table: unknown) {
+  const handlers: GateHandler[] = [];
+  const processed = new Set<string>();
+
+  async function logToVault(msg: GateMessage) {
+    await db.insert(table).values({
+      messageId: msg.id,
+      context: 'Gate',
+      fromWorld: msg.fromWorld,
+      toWorld: msg.toWorld,
+      payload: JSON.stringify(msg.payload),
+      orientation: msg.orientation,
+    });
+  }
+
+  async function deliver(handler: GateHandler, msg: GateMessage, attempt = 0): Promise<void> {
+    try {
+      await handler(msg);
+    } catch (err) {
+      if (attempt < 3) {
+        setTimeout(() => deliver(handler, msg, attempt + 1), (attempt + 1) * 100);
+      } else {
+        console.error('Failed GateMessage delivery', msg.id, err);
+      }
+    }
+  }
+
+  async function sendGateMessage(msg: GateMessage): Promise<void> {
+    if (processed.has(msg.id)) return;
+    processed.add(msg.id);
+    await logToVault(msg);
+    for (const handler of handlers) {
+      await deliver(handler, msg);
+    }
+  }
+
+  function onGateMessage(handler: GateHandler): void {
+    handlers.push(handler);
+  }
+
+  return { sendGateMessage, onGateMessage };
+}

--- a/tests/unit/api/entrance-way.test.ts
+++ b/tests/unit/api/entrance-way.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
 import * as bunTest from 'bun:test';
 
 // Bun's vi helper lacks `mock`, so map it when missing
@@ -17,6 +17,7 @@ vi.mock('drizzle-orm/sqlite-core', () => ({
   text: () => ({ notNull: () => ({}) })
 }));
 vi.mock('../../../packages/db/src/schema', () => ({ pages: {}, sections: {} }));
+vi.mock('/workspace/gibsey/packages/db/src/schema', () => ({ pages: {}, sections: {} }));
 vi.mock('@trpc/server', () => ({ initTRPC: () => ({ context: () => ({ create: () => ({ router: (obj: any) => obj }) }) }) }));
 vi.mock('drizzle-orm', () => ({ eq: () => ({}), and: () => ({}), like: () => ({}) }));
 vi.mock('../../../apps/api/auth/middleware', () => ({ authMiddleware: () => {} }));
@@ -26,8 +27,12 @@ vi.mock('../../../the-corpus/symbols/metadata', () => ({
   symbolMetadata: [{ character: 'Test', filename: 'a.svg', color: '#fff', orientation: 'upright' }],
 }));
 vi.mock('../../../packages/db/src/schema.ts', () => ({ pages: {}, sections: {} }));
+vi.mock('/workspace/gibsey/packages/db/src/schema.ts', () => ({ pages: {}, sections: {} }));
 
-import * as router from '../../../apps/api/src/router';
+let router: typeof import('../../../apps/api/src/router');
+beforeAll(async () => {
+  router = await import('../../../apps/api/src/router');
+});
 
 const mockDb = {
   select: vi.fn().mockReturnThis(),

--- a/tests/unit/gate.test.ts
+++ b/tests/unit/gate.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as bunTest from 'bun:test';
+import type { GateMessage } from '../../packages/types/gate';
+
+if (!('mock' in vi)) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (vi as any).mock = (bunTest as any).mock;
+}
+
+const insertMock = vi.fn();
+
+vi.mock('drizzle-orm/sqlite-core', () => ({
+  sqliteTable: () => ({}),
+  integer: () => ({ primaryKey: () => ({}) }),
+  text: () => ({ notNull: () => ({ unique: () => ({}) }) }),
+}));
+vi.mock('drizzle-orm', () => ({ eq: () => ({}) }));
+
+const vaultTable = {};
+
+import { createGate } from '../../services/mnr/gate';
+
+const { sendGateMessage, onGateMessage } = createGate(
+  { insert: () => ({ values: insertMock }) },
+  vaultTable
+);
+
+describe('GateMessage flow', () => {
+  beforeEach(() => {
+    insertMock.mockClear();
+  });
+
+  it('stores and processes message', async () => {
+    const received: GateMessage[] = [];
+    onGateMessage(msg => received.push(msg));
+    const msg: GateMessage = {
+      id: '1',
+      action: 'Read',
+      context: 'Page',
+      state: 'Public',
+      role: 'Human',
+      relation: 'SubjectToObject',
+      polarity: 'Internal',
+      orientation: 'N',
+      fromWorld: 'A',
+      toWorld: 'B',
+      payload: { ok: true },
+    };
+    await sendGateMessage(msg);
+    expect(received).toHaveLength(1);
+    expect(received[0].id).toBe('1');
+    expect(insertMock).toHaveBeenCalled();
+  });
+
+  it('deduplicates messages by id', async () => {
+    const msg: GateMessage = {
+      id: 'dedupe',
+      action: 'Read',
+      context: 'Page',
+      state: 'Public',
+      role: 'Human',
+      relation: 'SubjectToObject',
+      polarity: 'Internal',
+      orientation: 'N',
+      fromWorld: 'A',
+      toWorld: 'B',
+      payload: null,
+    };
+    await sendGateMessage(msg);
+    await sendGateMessage(msg);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add GateMessage types for MNR communication
- create MNR gate module with send/on helpers and retry
- store Gate messages to `vault_entries` via injected DB
- document new Gate types
- test sending and deduplication logic

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test'; schema mocks failing)*