### PR TITLE
Fix test setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ newer), and **Python 3** installed.
 
 ## Running Tests
 
-Run the TypeScript unit tests with `bun test`. Python tests are executed with `pytest`.
+Install JavaScript dev dependencies with `bun install` to ensure packages like `@playwright/test`, `hono`, and `drizzle-orm` are available. Install Python tooling with `pip install pytest`.
+
+Run the TypeScript unit tests with `bun test`. Python tests are executed with `pytest`. End-to-end tests use Playwright and can be run with `bun x playwright test` (or `bunx playwright test` if you have the `bunx` helper installed).
 
 ---

--- a/package.json
+++ b/package.json
@@ -8,5 +8,10 @@
     "playwright:test": "bun x playwright test",
     "pytest": "pytest",
     "test:all": "bun run test && bun run pytest && bun run playwright:test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.1",
+    "hono": "^3.11.0",
+    "drizzle-orm": "^0.29.0"
   }
 }

--- a/tests/unit/api/entrance-way.test.ts
+++ b/tests/unit/api/entrance-way.test.ts
@@ -13,12 +13,22 @@ vi.mock('drizzle-orm/bun-sqlite', () => ({ drizzle: () => ({}) }));
 vi.mock('bun:sqlite', () => ({ Database: class {} }));
 vi.mock('drizzle-orm/sqlite-core', () => ({
   sqliteTable: () => ({}),
-  integer: () => ({ primaryKey: () => ({}) }),
+  integer: () => ({
+    primaryKey: () => ({}),
+    references: () => ({ notNull: () => ({}) }),
+    notNull: () => ({ unique: () => ({}) }),
+    unique: () => ({})
+  }),
   text: () => ({ notNull: () => ({}) })
 }));
 vi.mock('../../../packages/db/src/schema', () => ({ pages: {}, sections: {} }));
 vi.mock('@trpc/server', () => ({ initTRPC: () => ({ context: () => ({ create: () => ({ router: (obj: any) => obj }) }) }) }));
-vi.mock('drizzle-orm', () => ({ eq: () => ({}), and: () => ({}), like: () => ({}) }));
+vi.mock('drizzle-orm', () => ({
+  eq: () => ({}),
+  and: () => ({}),
+  like: () => ({}),
+  relations: () => ({})
+}));
 vi.mock('../../../apps/api/auth/middleware', () => ({ authMiddleware: () => {} }));
 
 // Mock BOTH possible symbol and schema imports for router dependencies


### PR DESCRIPTION
## Summary
- add devDependencies for playwright, hono and drizzle
- update README with installation and test commands
- fix drizzle mock chain in API unit tests

## Testing
- `bun test` *(fails: integer.primaryKey is not a function)*
- `python -m pytest tests/unit/test_chunk_text.py` *(fails: No module named pytest)*
- `bun x playwright test` *(fails: ConnectionRefused downloading package manifest playwright)*