### PR TITLE
Add QDPI hypercube diagram

### DIFF
--- a/docs/qdpi-hypercube.svg
+++ b/docs/qdpi-hypercube.svg
@@ -1,0 +1,98 @@
+<svg viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg" font-family="monospace" font-size="14">
+  <style>
+    .axis-label { font-size: 14px; font-weight: bold; text-anchor: middle; }
+    .gate { stroke:#000; stroke-width:2; }
+  </style>
+  <!-- radial axes -->
+  <line x1="400" y1="300" x2="600" y2="300" stroke="#ef4444" stroke-width="3"/>
+  <text x="620" y="300" class="axis-label" fill="#ef4444">Action</text>
+
+  <line x1="400" y1="300" x2="541.42" y2="158.58" stroke="#f97316" stroke-width="3"/>
+  <text x="555.56" y="144.44" class="axis-label" fill="#f97316">Context</text>
+
+  <line x1="400" y1="300" x2="400" y2="100" stroke="#eab308" stroke-width="3"/>
+  <text x="400" y="80" class="axis-label" fill="#eab308">State</text>
+
+  <line x1="400" y1="300" x2="258.58" y2="158.58" stroke="#22c55e" stroke-width="3"/>
+  <text x="244.44" y="144.44" class="axis-label" fill="#22c55e">Role</text>
+
+  <line x1="400" y1="300" x2="200" y2="300" stroke="#14b8a6" stroke-width="3"/>
+  <text x="180" y="300" class="axis-label" fill="#14b8a6">Relation</text>
+
+  <line x1="400" y1="300" x2="258.58" y2="441.42" stroke="#0ea5e9" stroke-width="3"/>
+  <text x="244.44" y="455.56" class="axis-label" fill="#0ea5e9">Polarity</text>
+
+  <line x1="400" y1="300" x2="400" y2="500" stroke="#a855f7" stroke-width="3"/>
+  <text x="400" y="520" class="axis-label" fill="#a855f7">Rotation</text>
+
+  <line x1="400" y1="300" x2="541.42" y2="441.42" stroke="#ec4899" stroke-width="3"/>
+  <text x="555.56" y="455.56" class="axis-label" fill="#ec4899">Modality</text>
+
+  <!-- central glyph node -->
+  <rect x="370" y="270" width="60" height="60" fill="#fff" stroke="#000" stroke-width="2"/>
+  <!-- actor gates (left) -->
+  <rect x="360" y="276" width="8" height="8" class="gate" fill="#000"/>
+  <rect x="360" y="288" width="8" height="8" class="gate" fill="#fff"/>
+  <rect x="360" y="300" width="8" height="8" class="gate" fill="#000"/>
+  <rect x="360" y="312" width="8" height="8" class="gate" fill="#fff"/>
+  <!-- object gates (right) -->
+  <rect x="432" y="276" width="8" height="8" class="gate" fill="#000"/>
+  <rect x="432" y="288" width="8" height="8" class="gate" fill="#fff"/>
+  <rect x="432" y="300" width="8" height="8" class="gate" fill="#000"/>
+  <rect x="432" y="312" width="8" height="8" class="gate" fill="#fff"/>
+
+  <!-- polarity icons -->
+  <g transform="translate(370,230) scale(0.05)">
+    <!-- Princhetta symbol (inward) -->
+    <rect width="1000" height="1000" fill="#fff"/>
+    <line x1="200" y1="200" x2="800" y2="200" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    <line x1="200" y1="200" x2="200" y2="800" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    <line x1="800" y1="200" x2="800" y2="800" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    <line x1="200" y1="800" x2="400" y2="800" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    <line x1="200" y1="700" x2="400" y2="700" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    <line x1="200" y1="600" x2="400" y2="600" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    <line x1="200" y1="500" x2="400" y2="500" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    <line x1="800" y1="800" x2="600" y2="800" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    <line x1="800" y1="700" x2="600" y2="700" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    <line x1="800" y1="600" x2="600" y2="600" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    <line x1="800" y1="500" x2="600" y2="500" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+  </g>
+  <text x="400" y="225" text-anchor="middle" font-size="12">Princhetta “n” (inward)</text>
+
+  <g transform="translate(410,230) scale(0.05)">
+    <!-- Cop-E-Right symbol (outward) -->
+    <g transform="rotate(180 500 500)">
+      <rect width="1000" height="1000" fill="#fff"/>
+      <line x1="200" y1="200" x2="800" y2="200" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+      <line x1="200" y1="200" x2="200" y2="800" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+      <line x1="800" y1="200" x2="800" y2="800" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+      <line x1="200" y1="800" x2="0" y2="800" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+      <line x1="200" y1="700" x2="0" y2="700" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+      <line x1="200" y1="600" x2="0" y2="600" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+      <line x1="200" y1="500" x2="0" y2="500" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+      <line x1="800" y1="800" x2="1000" y2="800" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+      <line x1="800" y1="700" x2="1000" y2="700" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+      <line x1="800" y1="600" x2="1000" y2="600" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+      <line x1="800" y1="500" x2="1000" y2="500" stroke="#000" stroke-width="60" stroke-linecap="square"/>
+    </g>
+  </g>
+  <text x="440" y="225" text-anchor="middle" font-size="12">Cop‑E‑Right “u” (outward)</text>
+
+  <!-- rotation arrows -->
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="6" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#000"/>
+    </marker>
+  </defs>
+  <line x1="400" y1="250" x2="400" y2="210" stroke="#a855f7" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="400" y="200" text-anchor="middle">N</text>
+
+  <line x1="450" y1="300" x2="490" y2="300" stroke="#a855f7" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="502" y="304" text-anchor="start">E</text>
+
+  <line x1="400" y1="350" x2="400" y2="390" stroke="#a855f7" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="400" y="405" text-anchor="middle">S</text>
+
+  <line x1="350" y1="300" x2="310" y2="300" stroke="#a855f7" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="298" y="304" text-anchor="end">W</text>
+</svg>

--- a/the-QDPI-matrix.md
+++ b/the-QDPI-matrix.md
@@ -26,12 +26,9 @@ Below is the *generative matrix* for QDPI‑92,160—**every “cell” is a uni
 
 ---
 
-## Sample Glyph Visualization (Placeholder)
+## Sample Glyph Visualization
 
-*(Consider inserting a visual diagram or image of a sample glyph here. For example, a Princhetta/Cop-E-Right variant with the gates highlighted to illustrate the visual encoding.)*
-
-**Example Markdown for an image (you would replace this with your actual image path):**
-`![Sample Glyph](path_to_your_glyph_image.png "Sample QDPI Glyph")`
+![QDPI Hypercube](docs/qdpi-hypercube.svg "QDPI‑92,160 Hypercube")
 
 ---
 


### PR DESCRIPTION
## Summary
- add an SVG depicting the 8-axis QDPI hypercube
- embed the diagram in the matrix spec

## Testing
- `git status --short`