### PR TITLE
feat(utils): Implement QDPI 17-bit glyph packing/unpacking utilities

### DIFF
--- a/packages/utils/qdpiPackedCodec.ts
+++ b/packages/utils/qdpiPackedCodec.ts
@@ -1,0 +1,70 @@
+export function packQdpiGlyphs(glyphs: number[]): Uint8Array {
+  const outputBytes: number[] = [];
+  let bitBuffer = 0n;
+  let bitsInBuffer = 0;
+
+  for (const glyph of glyphs) {
+    // Input Validation
+    if (glyph < 0 || glyph > 131071) {
+      throw new RangeError(
+        `Glyph value ${glyph} is out of the 17-bit range (0-131071).`
+      );
+    }
+
+    // Add the 17 bits of the current glyph to the bitBuffer
+    bitBuffer = (bitBuffer << 17n) | BigInt(glyph);
+    bitsInBuffer += 17;
+
+    // While bitsInBuffer >= 8
+    while (bitsInBuffer >= 8) {
+      // Extract the most significant 8 bits from bitBuffer
+      const byteToWrite = Number(
+        (bitBuffer >> BigInt(bitsInBuffer - 8)) & 0xffn
+      );
+      outputBytes.push(byteToWrite);
+      bitsInBuffer -= 8;
+      // Remove the extracted bits from bitBuffer (optional, as the shift in byteToWrite handles it, but good for clarity if bitBuffer is masked)
+      bitBuffer &= (1n << BigInt(bitsInBuffer)) - 1n; // Keep only the remaining lower bits
+    }
+  }
+
+  // After processing all glyphs, if bitsInBuffer > 0
+  if (bitsInBuffer > 0) {
+    // There are leftover bits. These should be written as the final byte, MSB-aligned and padded with zeros at the LSB end.
+    const finalByte = Number(
+      (bitBuffer & ((1n << BigInt(bitsInBuffer)) - 1n)) <<
+        BigInt(8 - bitsInBuffer)
+    );
+    outputBytes.push(finalByte);
+  }
+
+  return Uint8Array.from(outputBytes);
+}
+
+export function unpackQdpiGlyphs(packed: Uint8Array): number[] {
+  let bitBuffer = 0n;
+  let bitsInBuffer = 0;
+  const outputGlyphs: number[] = [];
+  const GLYPH_BITS = 17;
+  const GLYPH_MASK = (1n << BigInt(GLYPH_BITS)) - 1n;
+
+  for (const byte of packed) {
+    bitBuffer = (bitBuffer << 8n) | BigInt(byte);
+    bitsInBuffer += 8;
+
+    while (bitsInBuffer >= GLYPH_BITS) {
+      const glyph = Number(
+        (bitBuffer >> BigInt(bitsInBuffer - GLYPH_BITS)) & GLYPH_MASK
+      );
+      outputGlyphs.push(glyph);
+      bitsInBuffer -= GLYPH_BITS;
+      // Optional: Mask bitBuffer to keep only remaining lower bits
+      bitBuffer &= (1n << BigInt(bitsInBuffer)) - 1n;
+    }
+  }
+
+  // Trailing bits that are less than GLYPH_BITS are ignored,
+  // as they represent padding from the packQdpiGlyphs function.
+
+  return outputGlyphs;
+}

--- a/tests/unit/qdpiPackedCodec.test.ts
+++ b/tests/unit/qdpiPackedCodec.test.ts
@@ -1,0 +1,74 @@
+import {
+  packQdpiGlyphs,
+  unpackQdpiGlyphs,
+} from '../../packages/utils/qdpiPackedCodec';
+
+describe('packQdpiGlyphs and unpackQdpiGlyphs - Round Trip', () => {
+  function RountTripTest(glyphs: number[]) {
+    const packed = packQdpiGlyphs(glyphs);
+    const unpacked = unpackQdpiGlyphs(packed);
+    expect(unpacked).toEqual(glyphs);
+  }
+
+  it('should correctly pack and unpack an empty glyph array', () => {
+    const glyphs: number[] = [];
+    const packed = packQdpiGlyphs(glyphs);
+    expect(packed).toEqual(new Uint8Array([]));
+    const unpacked = unpackQdpiGlyphs(packed);
+    expect(unpacked).toEqual(glyphs);
+  });
+
+  it('should correctly pack and unpack a single glyph', () => {
+    RountTripTest([12345]);
+  });
+
+  it('should correctly pack and unpack multiple glyphs that result in perfect byte alignment', () => {
+    const glyphs = Array(8)
+      .fill(0)
+      .map((_, i) => i + 1); // 8 glyphs * 17 bits = 136 bits = 17 bytes
+    RountTripTest(glyphs);
+  });
+
+  it('should correctly pack and unpack multiple glyphs with leftover bits', () => {
+    RountTripTest([1, 2, 3]); // 3 glyphs * 17 bits = 51 bits
+  });
+
+  it('should correctly pack and unpack glyphs with value 0', () => {
+    RountTripTest([0, 0, 0]);
+  });
+
+  it('should correctly pack and unpack glyphs with maximum 17-bit value', () => {
+    RountTripTest([131071, 131071]); // 2^17 - 1
+  });
+
+  it('should correctly pack and unpack mixed glyph values', () => {
+    RountTripTest([0, 131071, 123, 45678, 99999]);
+  });
+
+  it('should correctly pack and unpack a longer sequence of pseudo-random glyphs', () => {
+    const glyphs: number[] = [];
+    for (let i = 0; i < 100; i++) {
+      glyphs.push(Math.floor(Math.random() * 131072)); // Generate numbers between 0 and 2^17 - 1
+    }
+    RountTripTest(glyphs);
+  });
+});
+
+describe('packQdpiGlyphs - Error Handling', () => {
+  it('should throw RangeError for glyph value too large', () => {
+    expect(() => packQdpiGlyphs([131072])).toThrow(RangeError);
+    expect(() => packQdpiGlyphs([2 ** 17])).toThrow(RangeError);
+  });
+
+  it('should throw RangeError for negative glyph value', () => {
+    expect(() => packQdpiGlyphs([-1])).toThrow(RangeError);
+  });
+
+  it('should throw RangeError for mixed valid and invalid glyphs (too large)', () => {
+    expect(() => packQdpiGlyphs([10, 20, 131072, 30])).toThrow(RangeError);
+  });
+
+  it('should throw RangeError for mixed valid and invalid glyphs (negative)', () => {
+    expect(() => packQdpiGlyphs([10, 20, -5, 30])).toThrow(RangeError);
+  });
+});


### PR DESCRIPTION
Adds new functions `packQdpiGlyphs` and `unpackQdpiGlyphs` in `packages/utils/qdpiPackedCodec.ts` for efficiently serializing and deserializing arrays of 17-bit integer glyphs.

The `packQdpiGlyphs` function takes an array of numbers (17-bit glyphs), validates each glyph is within the 0-131071 range, and packs them densely into a Uint8Array using bitwise operations (MSB-first). Leftover bits in the final byte are padded with zeros at the LSB end.

The `unpackQdpiGlyphs` function takes a Uint8Array and unpacks it back into an array of 17-bit glyph numbers (MSB-first).

Comprehensive unit tests have been added in
`tests/unit/qdpiPackedCodec.test.ts` to ensure correctness, including round-trip tests for various scenarios (empty arrays, single/multiple glyphs, perfect/imperfect byte alignment, boundary values) and error handling for out-of-range glyph inputs during packing.